### PR TITLE
refactor(curator): curate() retorna sources_used como terceiro elemento

### DIFF
--- a/packages/maestra-ai/src/maestra_ai/cli/playlist.py
+++ b/packages/maestra-ai/src/maestra_ai/cli/playlist.py
@@ -22,7 +22,7 @@ def cmd_playlist_list(args, controller, **_):
 def cmd_playlist_add(args, controller, taste, curator, context_state, **_):
     playlist_id = resolve_playlist_id()
     context, context_source = _curation_context(args, context_state)
-    results, queries_used = curator.curate(context, count=args.count)
+    results, queries_used, _sources = curator.curate(context, count=args.count)
     if not results:
         error("Não consegui encontrar faixas para esse contexto.", "NO_RESULTS")
     uris = [r["uri"] for r in results]
@@ -55,7 +55,7 @@ def cmd_playlist_top_up(args, controller, taste, curator, context_state, **_):
         }, args.human)
         return
 
-    results, queries_used = curator.curate(
+    results, queries_used, _sources = curator.curate(
         context,
         count=needed,
         exclude_uris=existing_uris,

--- a/packages/maestra-ai/tests/unit/test_cli.py
+++ b/packages/maestra-ai/tests/unit/test_cli.py
@@ -48,6 +48,7 @@ def test_playlist_add_aceita_argumentos_extras_do_dispatcher(capsys):
             {"track": "Track B", "artist": "Artist B", "uri": "spotify:track:b"},
         ],
         ["foco instrumental"],
+        [],
     )
 
     cli.cmd_playlist_add(
@@ -76,6 +77,7 @@ def test_playlist_add_sem_contexto_usa_fallback_foco(capsys):
     curator.curate.return_value = (
         [{"track": "Track A", "artist": "Artist A", "uri": "spotify:track:a"}],
         ["lo-fi instrumental"],
+        [],
     )
 
     cli.cmd_playlist_add(
@@ -103,6 +105,7 @@ def test_playlist_add_sem_contexto_usa_contexto_ativo(capsys):
     curator.curate.return_value = (
         [{"track": "Track A", "artist": "Artist A", "uri": "spotify:track:a"}],
         ["epic orchestral"],
+        [],
     )
 
     cli.cmd_playlist_add(
@@ -135,6 +138,7 @@ def test_playlist_top_up_aceita_argumentos_extras_do_dispatcher(capsys):
             {"track": "Track C", "artist": "Artist C", "uri": "spotify:track:c"},
         ],
         ["foco instrumental"],
+        [],
     )
 
     cli.cmd_playlist_top_up(

--- a/packages/maestra-ai/tests/unit/test_cli_basic.py
+++ b/packages/maestra-ai/tests/unit/test_cli_basic.py
@@ -63,7 +63,7 @@ class TestQueueContextFailedField:
             {"uri": "spotify:track:t1", "track": "a", "artist": "x"},
             {"uri": "spotify:track:t2", "track": "b", "artist": "y"},
         ]
-        curator.curate.return_value = (tracks, ["q1"])
+        curator.curate.return_value = (tracks, ["q1"], [])
 
         def _queue_add(uri):
             if uri == "spotify:track:t2":
@@ -101,7 +101,7 @@ class TestQueueContextFailedField:
         tracks = [
             {"uri": "spotify:track:t1", "track": "a", "artist": "x"},
         ]
-        curator.curate.return_value = (tracks, ["q1"])
+        curator.curate.return_value = (tracks, ["q1"], [])
 
         args = MagicMock(human=False, count=1)
         args.context = None

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -33,7 +33,7 @@ def curator(mock_controller, taste):
 
 class TestCurate:
     def test_retorna_uris_para_contexto_semantico(self, curator, mock_controller):
-        result, queries = curator.curate("foco", count=3)
+        result, queries, _sources = curator.curate("foco", count=3)
 
         assert len(result) <= 3
         assert all(r["uri"].startswith("spotify:track:") for r in result)
@@ -42,14 +42,14 @@ class TestCurate:
 
     def test_retorna_lista_vazia_se_search_falha(self, curator, mock_controller):
         mock_controller.search.return_value = []
-        result, queries = curator.curate("contexto impossível", count=5)
+        result, queries, _sources = curator.curate("contexto impossível", count=5)
         assert result == []
 
     def test_filtra_faixas_rejeitadas(self, curator, mock_controller, taste):
         taste.record_feedback("spotify:track:a", "bad")
         taste.save()
 
-        result, _ = curator.curate("foco", count=5)
+        result, _, _sources = curator.curate("foco", count=5)
         uris = [r["uri"] for r in result]
         assert "spotify:track:a" not in uris
 
@@ -60,14 +60,14 @@ class TestCurate:
             "last_used": "2026-04-16",
         }
 
-        _, queries = curator.curate("energia", count=3)
+        _, queries, _sources = curator.curate("energia", count=3)
 
         assert "power metal" in queries
         calls = [str(c) for c in mock_controller.search.call_args_list]
         assert any("power metal" in c for c in calls)
 
     def test_exclui_uris_ja_presentes(self, curator):
-        result, _ = curator.curate("foco", count=3, exclude_uris={"spotify:track:a"})
+        result, _, _sources = curator.curate("foco", count=3, exclude_uris={"spotify:track:a"})
 
         uris = [r["uri"] for r in result]
         assert "spotify:track:a" not in uris
@@ -81,7 +81,7 @@ class TestCurate:
         ]
         mock_controller.search.return_value = first_results
 
-        result, _ = curator.curate(
+        result, _, _sources = curator.curate(
             "foco",
             count=2,
             exclude_uris={"spotify:track:a", "spotify:track:b"},
@@ -99,7 +99,7 @@ class TestCurate:
             weight=2,
         )
 
-        result, _ = curator.curate("foco", count=3)
+        result, _, _sources = curator.curate("foco", count=3)
 
         assert result[0]["uri"] == "spotify:track:c"
 
@@ -112,7 +112,7 @@ class TestCurate:
             weight=-1,
         )
 
-        result, _ = curator.curate("foco", count=3)
+        result, _, _sources = curator.curate("foco", count=3)
         uris = [r["uri"] for r in result]
 
         assert "spotify:track:a" not in uris
@@ -126,13 +126,13 @@ class TestCurate:
             weight=-1,
         )
 
-        result, _ = curator.curate("foco", count=3)
+        result, _, _sources = curator.curate("foco", count=3)
         uris = [r["uri"] for r in result]
 
         assert "spotify:track:a" in uris
 
     def test_exclui_artistas_dominantes(self, curator):
-        result, _ = curator.curate(
+        result, _, _sources = curator.curate(
             "foco",
             count=3,
             exclude_artists={"Artist A"},
@@ -148,7 +148,7 @@ class TestCurate:
             {"track": "B1", "artist": "Artist B", "uri": "spotify:track:b1", "album": "Album"},
         ]
 
-        result, _ = curator.curate("foco", count=2, max_per_artist=1)
+        result, _, _sources = curator.curate("foco", count=2, max_per_artist=1)
 
         assert [r["uri"] for r in result] == ["spotify:track:a1", "spotify:track:b1"]
 

--- a/packages/maestra-ai/tests/unit/test_director.py
+++ b/packages/maestra-ai/tests/unit/test_director.py
@@ -103,6 +103,7 @@ def test_adiciona_a_playlist_quando_buffer_de_contexto_esta_baixo(tmp_path):
             {"track": "Track C", "artist": "Artist C", "uri": "spotify:track:c"},
         ],
         ["ambient study"],
+        [],
     )
 
     result = director.run_once(target=2, add_count=2)
@@ -138,6 +139,7 @@ def test_dry_run_nao_altera_playlist_nem_gosto(tmp_path):
     curator.curate.return_value = (
         [{"track": "Track B", "artist": "Artist B", "uri": "spotify:track:b"}],
         ["lo-fi instrumental"],
+        [],
     )
 
     result = director.run_once(target=1, add_count=1, dry_run=True)
@@ -169,6 +171,7 @@ def test_director_bloqueia_artista_dominante_na_curadoria(tmp_path):
     curator.curate.return_value = (
         [{"track": "Nova", "artist": "Nova", "uri": "spotify:track:n"}],
         ["ambient study"],
+        [],
     )
 
     result = director.run_once(target=10, add_count=1, max_artist_share=0.5)
@@ -291,6 +294,7 @@ def test_import_outside_seguro_ignora_sinal_contextual_negativo(tmp_path):
     curator.curate.return_value = (
         [{"track": "Track B", "artist": "Artist B", "uri": "spotify:track:b"}],
         ["ambient study"],
+        [],
     )
 
     result = director.run_once(target=10, add_count=1, import_outside="safe")


### PR DESCRIPTION
## Summary

- `Curator.curate()` agora retorna tupla de 3 elementos: `(tracks, queries_used, sources_used)` em vez de 2
- Callers em `cli/playlist.py` atualizados para desempacotar o novo elemento
- Testes de curator/cli/director ajustados

## Contexto

Expor `sources_used` (fontes externas efetivamente consultadas: MusicBrainz, Last.fm, GetSongBPM/Reccobeats) é pré-requisito para justificar decisões de curadoria — debug, explicabilidade e base para o trabalho da issue #8 (parser de negações + `_build_informed_query` real).

## Test plan

- [x] `uv run pytest packages/maestra-ai/tests/unit/test_curator.py` passa
- [x] `uv run pytest packages/maestra-ai/tests/unit/test_cli.py` passa
- [x] `uv run pytest packages/maestra-ai/tests/unit/test_director.py` passa
- [ ] Suite completa (`uv run pytest packages/maestra-ai`) — validar que não quebra nada além do escopo

🤖 Generated with [Claude Code](https://claude.com/claude-code)