### PR TITLE
fix(cli): adiciona __main__.py (closes #6)

### DIFF
--- a/packages/maestra-ai/src/maestra_ai/cli/__main__.py
+++ b/packages/maestra-ai/src/maestra_ai/cli/__main__.py
@@ -1,0 +1,16 @@
+"""Entry point para `python -m maestra_ai.cli`.
+
+Necessário porque `core/director.py` spawna o daemon via
+`[sys.executable, "-m", "maestra_ai.cli", "director", "run", ...]`.
+Sem este módulo, Python falha com "No module named maestra_ai.cli.__main__".
+
+Issue #6.
+"""
+from __future__ import annotations
+
+import sys
+
+from maestra_ai.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/maestra-ai/tests/unit/test_cli_main_module.py
+++ b/packages/maestra-ai/tests/unit/test_cli_main_module.py
@@ -1,0 +1,40 @@
+"""Regressão: garante que `python -m maestra_ai.cli` é invocável.
+
+O director (`core/director.py`) spawna `python -m maestra_ai.cli director run`
+como subprocess. Sem __main__.py no pacote cli/, o subprocess morre com
+"No module named maestra_ai.cli.__main__" e o daemon falha silenciosamente.
+
+Issue #6.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cli_pode_ser_invocado_como_modulo():
+    """`python -m maestra_ai.cli --help` deve retornar exit 0 e banner de ajuda."""
+    result = subprocess.run(
+        [sys.executable, "-m", "maestra_ai.cli", "--help"],
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, (
+        f"python -m maestra_ai.cli --help falhou (exit {result.returncode}): "
+        f"stderr={result.stderr.decode(errors='replace')!r}"
+    )
+    assert b"usage:" in result.stdout.lower() or b"maestra" in result.stdout.lower(), (
+        f"stdout não contém banner de ajuda: {result.stdout[:200]!r}"
+    )
+
+
+def test_cli_modulo_propaga_exit_code_de_subcomando_invalido():
+    """Subcomando inexistente deve retornar exit != 0, comprovando que main() é chamado."""
+    result = subprocess.run(
+        [sys.executable, "-m", "maestra_ai.cli", "--subcomando-que-nao-existe"],
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode != 0, (
+        "argparse deveria rejeitar flag desconhecida com exit != 0"
+    )


### PR DESCRIPTION
## Summary

- Cria `packages/maestra-ai/src/maestra_ai/cli/__main__.py` que delega para `cli.main()` e propaga exit code via `sys.exit()`
- Adiciona `packages/maestra-ai/tests/unit/test_cli_main_module.py` com dois testes de regressão que invocam o subprocess exatamente como o director faz

Closes #6.

## Contexto

Esta PR está **stacked sobre #9** (refactor curator sources_used). Sem o refactor da base, a suite quebra em 17 testes porque `curator.curate()` já retorna 3-tupla no main mas os callers/testes estavam desatualizados. Fazer merge de #9 primeiro, aí rebaseio/mergeio esta.

## Reprodução do bug (antes do fix)

\`\`\`bash
python -m maestra_ai.cli --help
# No module named maestra_ai.cli.__main__; 'maestra_ai.cli' is a package and cannot be directly executed
\`\`\`

## Validação (após o fix)

- [x] `python -m maestra_ai.cli --help` retorna exit 0 e mostra banner
- [x] `python -m maestra_ai.cli director run --help` (o comando exato que o daemon spawna) funciona
- [x] Teste red-green: primeiro rodei o teste novo e confirmei que falhava com a mensagem exata antes de adicionar `__main__.py`
- [x] Suite completa verde: **770 passed, 6 skipped, 14.79s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)