### PR TITLE
fix(mcp): director_once mapeia count -> add_count (closes #7)

### DIFF
--- a/packages/maestra-mcp/src/maestra_mcp/tools.py
+++ b/packages/maestra-mcp/src/maestra_mcp/tools.py
@@ -420,7 +420,9 @@ def _director_status(args):
           "count": {"type": "integer", "minimum": 1, "maximum": 20, "default": 2},
       }, "additionalProperties": False})
 def _director_once(args):
-    return build_deps()["director"].run_once(count=args.get("count", 2))
+    # MusicDirector.run_once() assina add_count=, não count=. O schema externo
+    # mantém `count` por ergonomia do consumidor MCP; mapeamos aqui.
+    return build_deps()["director"].run_once(add_count=args.get("count", 2))
 
 
 # =========================================================================

--- a/packages/maestra-mcp/tests/test_tools.py
+++ b/packages/maestra-mcp/tests/test_tools.py
@@ -273,6 +273,32 @@ async def test_director_once_chama_run_once():
 
 
 @pytest.mark.asyncio
+async def test_director_once_respeita_assinatura_real_de_run_once():
+    """Regressão issue #7: o handler deve passar kwargs compatíveis com
+    MusicDirector.run_once(). MagicMock(spec=...) valida kwargs contra a
+    assinatura real — se o handler passar `count=` (kwarg inexistente),
+    o mock levanta TypeError exatamente como o director de verdade.
+    """
+    from maestra_ai.core.director import MusicDirector
+    from maestra_mcp.tools import call_tool
+
+    mock_director = MagicMock(spec=MusicDirector)
+    mock_director.run_once.return_value = {"added": 0, "action": "hold"}
+    with patch("maestra_mcp.tools.build_deps", return_value={"director": mock_director}):
+        result = await call_tool("director_once", {"count": 5})
+    # Sem o fix, esta asserção nunca é alcançada: TypeError acontece antes.
+    assert "error" not in result, f"director_once retornou erro: {result}"
+    # Valida que o kwarg correto (add_count) foi propagado do MCP.
+    kwargs = mock_director.run_once.call_args.kwargs
+    assert kwargs.get("add_count") == 5, (
+        f"Esperava add_count=5 em kwargs, obtido: {kwargs}"
+    )
+    assert "count" not in kwargs, (
+        f"kwarg 'count' não deveria vazar para o director (assinatura real usa add_count): {kwargs}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_onboard_default_e_dry_run():
     # Garante que chamar onboard sem argumentos é seguro: dry_run=True.
     from maestra_mcp.tools import call_tool


### PR DESCRIPTION
## Summary

- Handler `_director_once` em `packages/maestra-mcp/src/maestra_mcp/tools.py:422` agora passa `add_count=` para `MusicDirector.run_once()` (era `count=`, kwarg inexistente)
- Schema externo do MCP mantém `count` por ergonomia do consumidor
- Adiciona teste de regressão que pega o bug real (o teste existente usava `MagicMock` sem `spec` e não detectava kwargs errados)

Closes #7.

## Contexto

Independente da PR #9. O fix toca só `packages/maestra-mcp/`, que consome `maestra-ai` como dependência mas não é afetado pelo refactor do curator.

## Reprodução do bug (antes do fix)

\`\`\`json
// MCP director_once call
{"error": {"code": "TypeError", "what_happened": "MusicDirector.run_once() got an unexpected keyword argument 'count'"}}
\`\`\`

## Validação

- [x] Teste red-green: novo teste falhava com `{'count': 5}` em kwargs antes do fix, passa com `{'add_count': 5}` depois
- [x] Suite maestra-mcp verde: **51 passed, 1.34s**
- [ ] Teste end-to-end via MCP real: só validável após reinício do Claude Code que usa o servidor MCP — o próprio consumidor/reporter do bug vai confirmar no próximo startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)