### PR TITLE
feat(mcp): expõe serverInfo.instructions orientando agente LLM (closes #14)

### DIFF
--- a/packages/maestra-mcp/docs/instructions.md
+++ b/packages/maestra-mcp/docs/instructions.md
@@ -1,0 +1,133 @@
+# MCP serverInfo.instructions
+
+Este documento explica o racional, a estrutura e o processo de evolução
+das instructions que o servidor `maestra-mcp` expõe no handshake MCP.
+
+## O que são
+
+O protocolo MCP permite que um servidor declare uma string de orientação
+(`serverInfo.instructions`) na resposta do handshake inicial. Clientes
+compatíveis — Claude Code, Codex CLI, Gemini CLI — injetam essa string
+automaticamente no contexto inicial da conversa com o agente LLM.
+
+Exemplo de como Claude Code apresenta as instructions no prompt:
+
+```
+## MCP Server Instructions
+
+## maestra
+# Maestra MCP — Modelo mental
+
+Você é o diretor musical da sessão. Este servidor é seu estúdio: memória
+estruturada de gosto, contexto e histórico do usuário, ...
+```
+
+O agente lê isso antes de qualquer interação com o usuário.
+
+## Modelo mental
+
+A arquitetura do maestra distingue duas camadas de inteligência:
+
+- **Maestra (servidor) — órgão sensorial-motor.** Armazena variáveis
+  estruturadas do usuário (`taste_profile`, `context`, histórico,
+  metadata externa via MB/LF/Reccobeats, scoring composto) e opera o
+  Spotify (`play`, `queue`, `skip`, `search`, `playlist_*`).
+- **LLM agente — córtex.** Lê o humor cognitivo e emocional da sessão,
+  dimensão que só o LLM acessa, e traduz isso em escolha musical,
+  operando a fila como extensão desse entendimento.
+
+O scoring composto automático (`play_context`, `director`) existe para
+quando não há agente no loop — CLI direto, director autônomo rodando em
+background. Com agente ativo, a primazia é do agente; o scoring vira
+fallback pra situações sem input recente.
+
+Essa divisão é o núcleo do valor do maestra-ai: curadoria contextual que
+combina conhecimento impessoal (o que é próximo estilisticamente de X)
+com conhecimento pessoal (o que este usuário gosta dentro desse estilo).
+Agente sem servidor = DJ sem conhecer o cliente. Servidor sem agente =
+banco de dados de gosto sem leitor do momento. Juntos = a proposta.
+
+## Estrutura das instructions
+
+Quatro blocos, cada um com objetivo específico:
+
+1. **Modelo mental.** Uma frase orientadora no topo: agente é diretor,
+   servidor é estúdio, primazia do agente com agente ativo.
+2. **Leitura de humor como entrada primária.** Dimensões a considerar
+   (tipo de trabalho, ritmo, emocional, temporal, meta), exemplos de
+   eixos musicais, afirmação de que só o LLM tem essa dimensão.
+3. **Uso das variáveis armazenadas.** Quais tools consultar antes de
+   enfileirar (`taste_review`, `get_context`, `queue`,
+   `history_outside_playlist`), como reagir a sinais do usuário
+   (`skip` = descompasso), quando usar `play_context` como fallback.
+4. **Limitações atuais.** Bugs conhecidos que afetam o uso do servidor
+   hoje (ex: `director_start` silencioso da issue #6, negações ignoradas
+   da issue #8). Avisos marcados com a issue correspondente; são
+   removidos quando o fix chega em produção.
+
+## Processo de evolução
+
+As instructions são ativo vivo. Atualizá-las é parte do release cycle
+quando houver mudança de comportamento que agentes consumidores precisam
+saber.
+
+### Quando atualizar
+
+- **Nova feature user-facing.** Nova tool expondo capacidade importante
+  (ex: `taste_review`, `flow_review`) deve aparecer no Bloco 3 ou 4.
+- **Fix de bug conhecido.** Quando um bug listado no Bloco 4 for
+  resolvido, remover o aviso correspondente no mesmo PR do fix.
+- **Mudança de comportamento.** Se semântica de uma tool muda de forma
+  não-retrocompatível (ex: default de `dry_run` trocando), mencionar
+  explicitamente.
+- **Descoberta de padrão de uso ruim.** Se feedback de uso real mostra
+  que agentes estão usando o servidor de forma subótima consistente
+  (caso que originou esta feature: agentes repondo fila via
+  `search + queue` manual em vez de `play_context`), refletir a
+  correção aqui.
+
+### Quando NÃO atualizar
+
+- Mudanças internas invisíveis ao agente (refactor, performance, etc.).
+- Novas tools auxiliares sem papel central no fluxo principal.
+- Bugs que afetam só a CLI, não o MCP.
+
+### Processo
+
+1. Editar `packages/maestra-mcp/src/maestra_mcp/instructions.py`.
+2. Rodar `uv run pytest packages/maestra-mcp/tests/test_instructions.py`
+   — os testes validam que os 4 blocos continuam presentes e que tools
+   críticas são citadas. Se o teste quebrar, revisar se o bloco foi
+   removido por engano ou se o teste precisa ser atualizado junto.
+3. Em releases, registrar no CHANGELOG no item "MCP server".
+4. Após PR merged, reiniciar o Claude Code (ou cliente equivalente) para
+   que o novo handshake traga as instructions atualizadas.
+
+## Testes
+
+`packages/maestra-mcp/tests/test_instructions.py` cobre:
+
+- `INSTRUCTIONS` é constante não-vazia e de tamanho razoável (> 500
+  chars).
+- Os 4 blocos estão presentes (via marcadores-chave: `diretor`,
+  `humor`/`cognitivo`/`emocional`, `taste`+`contexto`, `limitaç`/`bug`).
+- Tools críticas são citadas por nome (`taste_review`, `get_context`,
+  `set_context`, `queue`, `play_context`).
+- Bugs abertos são alertados (referência a `#6`, `#8` ou descrição).
+- Sanity check de segurança: nenhum path absoluto, nenhum token ou
+  credencial vaza.
+- `create_server()` passa `INSTRUCTIONS` ao SDK MCP corretamente via
+  kwarg `instructions=`.
+
+Os testes são intencionalmente tolerantes a reformulações — validam
+presença de conceitos, não de strings literais. Isso permite que as
+instructions evoluam sem forçar update constante dos testes.
+
+## Referência cruzada
+
+- **Issue #14** — origem desta feature.
+- **Issue #6** — `director_start` silencioso, mencionado no Bloco 4 até
+  fix chegar em main.
+- **Issue #8** — negações no contexto, mencionadas no Bloco 4 até v0.13.
+- **Spec de v0.13** —
+  `docs/superpowers/specs/2026-04-20-v0130-query-informada-negacoes-design.md`.

--- a/packages/maestra-mcp/src/maestra_mcp/instructions.py
+++ b/packages/maestra-mcp/src/maestra_mcp/instructions.py
@@ -1,0 +1,96 @@
+"""Instructions injetadas no handshake MCP (serverInfo.instructions).
+
+Orientam o agente LLM consumidor (Claude Code, Codex CLI, Gemini CLI) sobre
+o modelo mental de uso do servidor. Injetadas uma vez por sessão pelo
+cliente MCP, no contexto inicial da conversa.
+
+Racional e evolução documentados em `packages/maestra-mcp/docs/instructions.md`.
+
+Issue #14.
+"""
+from __future__ import annotations
+
+
+INSTRUCTIONS = """# Maestra MCP — Modelo mental
+
+Você é o diretor musical da sessão. Este servidor é seu estúdio: memória
+estruturada de gosto, contexto e histórico do usuário, e controle remoto
+do Spotify. A escolha de faixas é sua — combine sua leitura do humor da
+sessão com as variáveis persistidas aqui. O scoring composto do maestra
+(`play_context`) existe para quando não há agente no loop; com agente
+ativo, a primazia é do agente.
+
+## Ler humor antes de agir musicalmente
+
+Antes de enfileirar ou tocar, avalie o estado cognitivo e emocional do
+usuário pelos inputs recentes. Dimensões a considerar:
+
+- **Tipo de trabalho**: brainstorm técnico denso, escrita normativa,
+  debug concentrado, revisão calma, deploy tenso, análise crítica,
+  codificação em flow.
+- **Ritmo de interação**: ping-pong rápido vs pausas longas; frases
+  curtas vs prosa; listas vs discurso contínuo.
+- **Estado emocional**: neutro, empolgado, frustrado, cansado, em
+  conquista, exasperado.
+- **Contexto temporal**: madrugada profunda, entre reuniões,
+  pós-entrega, início de expediente.
+- **Sinais meta explícitos**: "preciso focar", "tô cansado", "vamos
+  retomar", "não tá funcionando".
+
+Traduza o diagnóstico em eixo musical concreto — denso instrumental
+cinematográfico, darksynth de momentum, post-rock introspectivo,
+power-metal de euforia, dark ambient de fim-de-noite, neoclássico
+minimalista, metal tribal de energia sustentada, etc. O vocabulário é
+seu; a diretriz é: **humor da sessão é entrada primária**. Só você (LLM)
+tem acesso a essa dimensão — o maestra não.
+
+## Cruzar humor com as variáveis armazenadas
+
+Antes de enfileirar ou chamar `play`:
+
+- `taste_review` — top positivos (artistas/tags que o usuário ama) e
+  rejeitados (marcados como "bad"). **Nunca enfileire sem checar
+  rejeitados.** Cruzar com seu eixo musical filtra escolhas genéricas
+  de gênero para escolhas aderentes a este usuário.
+- `get_context` — o contexto ativo ainda bate com o humor lido? Se não,
+  `set_context` com a nova leitura antes de curar. Contexto expirado
+  (TTL) também exige atualização.
+- `queue` — meça quantas faixas restam. Em sessão longa, reponha
+  proativamente quando a fila ficar abaixo de 5 faixas; não espere
+  o usuário avisar que a música acabou.
+- `history_outside_playlist` — o que o usuário toca fora da curadoria
+  maestra. Sinal puro de gosto sem influência do curator.
+
+Durante a sessão: `skip` manual do usuário é sinal de descompasso —
+reavalie o eixo imediatamente, não continue a fila como estava. Pausa
+longa e retorno após silêncio: considere verificar se o contexto ainda
+é o mesmo antes de agir.
+
+Quando não houver input recente do usuário (agente autônomo após longa
+pausa, sessão sem interação), `play_context` aciona o scoring composto
+do maestra como fallback confiável — usa taste, contexto ativo, BPM
+target e metadata externa pra curar sem depender de leitura em tempo
+real.
+
+## Curadoria não é busca
+
+`search` serve para tradução artista→URI quando você já sabe o que quer.
+Curadoria contextual com filtros automáticos de gosto e scoring deve
+passar por `play_context` ou `queue_context`, não por `search + queue`
+manual — a menos que você esteja deliberadamente conduzindo em modo
+DJ-explícito com filas curtas e intencionais.
+
+## Limitações atuais do servidor
+
+- **`director_start` pode falhar silenciosamente** (issue #6): o daemon
+  spawna `python -m maestra_ai.cli` que falha quando `__main__.py` está
+  ausente no pacote. Prefira curadoria sob demanda via `play_context`
+  até o fix chegar em produção.
+- **Curadoria automática não respeita negações no contexto** (issue #8,
+  v0.13): se o contexto ativo contém "evitar X" ou "sem Y", aplique
+  filtro manual após `play_context` — o scoring ainda não penaliza
+  tags negativas do cache external.
+
+Quando essas limitações forem resolvidas, os avisos correspondentes
+desta seção serão removidos.
+"""

--- a/packages/maestra-mcp/src/maestra_mcp/server.py
+++ b/packages/maestra-mcp/src/maestra_mcp/server.py
@@ -116,8 +116,15 @@ def _build_call_tool_handler():
 
 
 def create_server() -> Server:
-    """Cria instância do Server com handlers registrados."""
-    server = Server("maestra")
+    """Cria instância do Server com handlers registrados.
+
+    As `instructions` (issue #14) são injetadas no handshake pelo SDK MCP e
+    chegam ao cliente como `serverInfo.instructions`. Clientes como Claude
+    Code injetam automaticamente no contexto inicial do agente.
+    """
+    from maestra_mcp.instructions import INSTRUCTIONS
+
+    server = Server("maestra", instructions=INSTRUCTIONS)
     server.list_tools()(_build_list_tools_handler())
     server.call_tool()(_build_call_tool_handler())
     return server

--- a/packages/maestra-mcp/tests/test_instructions.py
+++ b/packages/maestra-mcp/tests/test_instructions.py
@@ -1,0 +1,91 @@
+"""Testes do serverInfo.instructions injetadas no handshake MCP.
+
+Issue #14. As instructions orientam o agente LLM consumidor (Claude Code,
+Codex CLI, Gemini CLI) sobre o modelo mental de uso do maestra-mcp —
+especialmente que o agente é o diretor musical e o servidor é seu estúdio
+de memória estruturada.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_instructions_module_exporta_constante():
+    from maestra_mcp.instructions import INSTRUCTIONS
+    assert isinstance(INSTRUCTIONS, str)
+    assert len(INSTRUCTIONS) > 500, (
+        "INSTRUCTIONS muito curta — deve cobrir 4 blocos com profundidade razoável"
+    )
+
+
+def test_instructions_cobre_os_quatro_blocos():
+    """Marcadores de seção pra garantir que nenhum bloco some num refactor."""
+    from maestra_mcp.instructions import INSTRUCTIONS
+    lower = INSTRUCTIONS.lower()
+    # Bloco 1: modelo mental
+    assert "diretor" in lower or "diretora" in lower, (
+        "falta menção ao papel de diretor(a) musical (Bloco 1 — modelo mental)"
+    )
+    # Bloco 2: leitura de humor
+    assert "humor" in lower or "estado cognitivo" in lower or "emocional" in lower, (
+        "falta orientação sobre ler humor da sessão (Bloco 2)"
+    )
+    # Bloco 3: cruzar com variáveis
+    assert "taste" in lower and "contexto" in lower, (
+        "falta orientação sobre consultar taste e contexto (Bloco 3)"
+    )
+    # Bloco 4: avisos de estado atual
+    assert "bug" in lower or "limitaç" in lower or "limitaçã" in lower, (
+        "falta seção de avisos sobre estado atual do servidor (Bloco 4)"
+    )
+
+
+def test_instructions_menciona_tools_criticas_por_nome():
+    from maestra_mcp.instructions import INSTRUCTIONS
+    criticas = ["taste_review", "get_context", "set_context", "queue", "play_context"]
+    for tool in criticas:
+        assert tool in INSTRUCTIONS, (
+            f"tool crítica '{tool}' não mencionada nas instructions — "
+            f"agentes podem não saber quando usá-la"
+        )
+
+
+def test_instructions_alerta_bugs_abertos():
+    """Enquanto #6 e #8 não forem fechadas, instructions devem alertar agentes.
+    Quando fecharem, remover os alertas e atualizar este teste."""
+    from maestra_mcp.instructions import INSTRUCTIONS
+    # Referências a números de issue ou descrição dos bugs
+    assert "#6" in INSTRUCTIONS or "director" in INSTRUCTIONS.lower(), (
+        "alerta sobre issue #6 (director daemon) ausente"
+    )
+    assert "#8" in INSTRUCTIONS or "negaç" in INSTRUCTIONS.lower() or "evitar" in INSTRUCTIONS.lower(), (
+        "alerta sobre issue #8 (negações no contexto) ausente"
+    )
+
+
+def test_create_server_passa_instructions_ao_sdk():
+    """O Server do SDK MCP deve receber as instructions no handshake."""
+    from maestra_mcp.server import create_server
+    from maestra_mcp.instructions import INSTRUCTIONS
+
+    srv = create_server()
+    # MCP SDK expõe instructions em server.instructions após init
+    assert hasattr(srv, "instructions"), (
+        "Server não tem atributo .instructions — versão do SDK incompatível?"
+    )
+    assert srv.instructions == INSTRUCTIONS, (
+        "Server.instructions diverge da constante INSTRUCTIONS — "
+        "fonte única da verdade quebrada"
+    )
+
+
+def test_instructions_nao_inclui_segredos_nem_paths_absolutos():
+    """Sanity check: a string é pública pra qualquer agente consumidor.
+    Nenhum token, nenhum path tipo /home/user, nenhum hostname interno."""
+    from maestra_mcp.instructions import INSTRUCTIONS
+    banned_patterns = ["/home/", "token", "secret", "password", "api_key"]
+    lower = INSTRUCTIONS.lower()
+    for pattern in banned_patterns:
+        assert pattern not in lower, (
+            f"INSTRUCTIONS contém padrão sensível '{pattern}' — revisar"
+        )


### PR DESCRIPTION
## Summary

- Servidor \`maestra-mcp\` agora declara \`instructions\` no handshake MCP
- Conteúdo em 4 blocos: modelo mental, leitura de humor, uso de variáveis armazenadas, limitações atuais
- Novo módulo \`instructions.py\`, 6 testes de snapshot, doc em \`docs/instructions.md\` com processo de evolução

Closes #14.

## Modelo mental comunicado

> Maestra = órgão sensorial-motor (taste, context, scoring, fila, Spotify API).
> LLM agente = córtex (lê humor cognitivo/emocional da sessão, traduz em escolha musical).
> \`play_context\` e scoring automático são fallback pra quando não há agente no loop.

## Validação

- [x] Teste red-green: 6 testes falhavam (ModuleNotFoundError) antes; passam depois
- [x] \`create_server()\` passa \`INSTRUCTIONS\` ao SDK via kwarg nativo
- [x] Suite maestra-mcp: **56 passed, 1.03s** (era 51)
- [x] Nenhum path absoluto, token ou credencial nas instructions (sanity check)
- [x] 4 blocos + tools críticas (\`taste_review\`, \`get_context\`, \`set_context\`, \`queue\`, \`play_context\`) citadas
- [x] Avisos sobre issues #6 e #8 presentes (remover quando fixados)
- [ ] Validação manual: reiniciar Claude Code após merge, confirmar que instructions aparecem em \`## MCP Server Instructions\` no próximo startup

## Referências

- Doc: \`packages/maestra-mcp/docs/instructions.md\` — racional, estrutura, processo de evolução
- Relacionado: PR #11 (fix #7), PR #12 (fix #6), spec em \`docs/superpowers/specs/2026-04-20-v0130-query-informada-negacoes-design.md\` (issue #8)

## Observação

Avisos do Bloco 4 serão removidos quando fixes chegarem: o aviso de #6 junto com merge de #12; o aviso de #8 junto com v0.13. Testes são tolerantes — só exigem \"alerta sobre director\" e \"alerta sobre negações\" como conceitos, não strings específicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)