### PR TITLE
feat(v0.13): query informada e negações semânticas (closes #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-04-21
+
+### Adicionado
+- **Parser unificado de contexto** (`context_parser.py`) com `ParsedContext`
+  frozen + hashable — campos `text`, `positive`, `negative`, `artists_hint`,
+  `bpm`. Markers positivos (`tipo`, `como`, `parecido com`, `mais`) e negativos
+  (`evitar`, `sem`, `não`, `nao`) parseados per-cláusula com normalização NFKC
+  + casefold. Artistas capitalizados capturados via regex em `artists_hint`
+  sem vazar pra `positive`.
+- **`BpmRange`** frozen dataclass (`min`, `max`, ambos `int | None`) substitui
+  `dict` no campo `bpm` do `ParsedContext` para preservar hashability. Aceita
+  ingress via dict `{min, max}` através de `BpmRange.from_any()`.
+- **`ContextState.parsed()`** memoizado por `(text, bpm)` com invalidação
+  automática em `set()`, `clear()` e `clear_bpm()`. Identidade preservada
+  entre chamadas idempotentes.
+- **`core/external/tag_filter.py`** — `filter_lastfm_tags()` remove meta-tags
+  (décadas, países, avaliativos), normaliza case e corta `top_n` por
+  popularidade. Base pra `_track_tags` real.
+- **`Curator._track_tags()`** real — consome cache external mergeando MB
+  (canônico) + LF (filtrado via `tag_filter`). Encerra stub de v0.10.0-alpha.1.
+  Desbloqueia `tag_similarity` no scoring composto.
+- **`Curator._build_informed_query(parsed)`** real — deriva query de
+  `ParsedContext` cruzado com `taste.get_preferred_artists()`, pulando top
+  taste que batem com `parsed.negative`. BPM target vira qualificador
+  (ex: `110bpm`).
+- **`Curator._apply_negative_filter`** — hard filter adaptativo: remove
+  candidatos com tag negada; se resultado < `MIN_CANDIDATES`, preserva
+  originais com `degraded=True` e log warning.
+- **`scoring.anti_tag_penalty`** — penalty proporcional ao overlap com tags
+  negadas, capped em 3, ativa só em modo degraded (`W_ANTI_TAG=0.4` inicial).
+
+### Alterado
+- **`Curator.curate()`** agora aceita `str` ou `ParsedContext` como contexto
+  (duck-typing via `hasattr(context, "text")`). Fluxo interno: parse → query
+  informada → fallback SEMANTIC_MAP → `enhance_many` → `_apply_negative_filter`
+  → re-rank com `anti_tag_penalty` quando degraded.
+
+### Corrigido
+- **Issue #8**: curadoria respeita negações ("evitar X", "sem Y") e usa tags
+  reais do cache external no scoring composto.
+
+### Relacionado
+- Issue #13 continua aberta para melhorias futuras: parser EN, threshold de
+  count em LF, cascade de ampliação da query informada, telemetria pra
+  calibrar weights. Também: regex de `_extract_artists` só pega `[A-Z]`
+  ASCII (gap em "José", "Ólafur"); shape `list[str]` de `lastfm.top_tags`
+  diverge do esperado pelo `filter_lastfm_tags` (wrap adapter em
+  `_track_tags` como solução de curto prazo).
+
 ## [0.12.0] — 2026-04-20
 
 ### Adicionado

--- a/docs/superpowers/plans/2026-04-20-v0130-query-informada-negacoes.md
+++ b/docs/superpowers/plans/2026-04-20-v0130-query-informada-negacoes.md
@@ -515,6 +515,35 @@ e \"nao\" idem. Texto original é preservado em ParsedContext.text."
 
 ---
 
+## Task 4.5: Fix BpmRange + artist leak (correção inline pós-review)
+
+> **Nota:** Esta task não estava no plano original. Foi executada inline após cumulative
+> quality review das Tasks 1–4. Commit: `4676df6`.
+
+**Problema 1 — hashability:** `bpm: dict | None` em `ParsedContext(frozen=True)` quebra
+hashability (dict é mutável e não hashável). Qualquer tentativa de usar o `ParsedContext`
+como chave de cache falharia.
+
+**Fix:** Novo `BpmRange` frozen dataclass com campos `min: int | None`, `max: int | None`
+e classmethod `from_any(BpmRange | dict | None) -> BpmRange | None`. Campo `ParsedContext.bpm`
+passa a ser `BpmRange | None`. `parse()` aceita dict para ergonomia dos callers existentes
+(converte via `from_any`). Camada de persistência em disco inalterada.
+
+**Problema 2 — artist leak:** `parse("tipo The HU")` colocava `"the"` (casefold do primeiro
+token) em `positive`. O matching usava o texto normalizado para decidir positive vs artist.
+
+**Fix:** `_extract_after_marker` refatorado para `_extract_after_marker_pair`, que devolve
+`(rest_norm, rest_original)`. A decisão positive-vs-artist usa o case ORIGINAL do primeiro
+token — só vai para `positive` se começar minúsculo no texto cru.
+
+**Arquivos alterados:**
+- `packages/maestra-ai/src/maestra_ai/core/context_parser.py`
+- `packages/maestra-ai/tests/unit/test_context_parser.py` (64 linhas de testes adicionados)
+
+- [x] **Executado** — ver commit `4676df6`
+
+---
+
 ## Task 5: Scaffold e implementação de `tag_filter.py`
 
 **Files:**
@@ -711,10 +740,11 @@ class TestParsed:
 
     def test_parsed_repass_bpm_do_context(self, tmp_path):
         from maestra_ai.core.context import ContextState
+        from maestra_ai.core.context_parser import BpmRange  # T4.5: bpm é BpmRange, não dict
         state = ContextState(tmp_path / "ctx.json")
         state.set("foco", bpm={"min": 60, "max": 90})
         p = state.parsed()
-        assert p.bpm == {"min": 60, "max": 90}
+        assert p.bpm == BpmRange(min=60, max=90)
 ```
 
 - [ ] **Step 3: Rodar e confirmar falhas**
@@ -1156,9 +1186,10 @@ class TestBuildInformedQuery:
         assert "metal" in q
 
     def test_bpm_adiciona_qualificador(self, curator, monkeypatch):
+        from maestra_ai.core.context_parser import BpmRange  # T4.5: bpm é BpmRange, não dict
         monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
         q = curator._build_informed_query(self._ctx(
-            positive=("metal",), bpm={"min": 100, "max": 120}
+            positive=("metal",), bpm=BpmRange(min=100, max=120)
         ))
         assert q is not None
         assert "metal" in q
@@ -1224,9 +1255,10 @@ def _build_informed_query(self, parsed) -> str | None:
     positive_part = parsed.positive[0] if parsed.positive else None
 
     # Parte 3: bpm qualifier
+    # T4.5: parsed.bpm é BpmRange (não dict) — acesso via atributo, não .get()
     bpm_part = None
-    if parsed.bpm and parsed.bpm.get("min") and parsed.bpm.get("max"):
-        mid = (parsed.bpm["min"] + parsed.bpm["max"]) // 2
+    if parsed.bpm is not None and parsed.bpm.min is not None and parsed.bpm.max is not None:
+        mid = (parsed.bpm.min + parsed.bpm.max) // 2
         bpm_part = f"{mid}bpm"
 
     # Se nenhuma parte produziu sinal, retorna None
@@ -1690,3 +1722,16 @@ git commit -m "docs: v0.13 do maestra-ai em memória e índice"
 - [ ] MCP instructions atualizadas (Task 14) — remove aviso do bug fixado.
 
 **Próximo passo após aprovação**: criar branch `feat/issue-8-v0130-query-informada-negacoes` a partir do `main` atualizado (pós-merge de #11, #12, #15, #16) e iniciar execução.
+
+---
+
+## Execução
+
+**Executado em:** 2026-04-21
+**Branch:** `feat/issue-8-v0130-query-informada-negacoes`
+**Commits:** `6fbca0e..0265af2`
+**Suite:** 891 passed, 0 failed
+**Issue #8:** fechada
+
+Divergências em relação ao plano original estão documentadas na Task 4.5 acima e na seção
+"Divergências implementadas vs spec original" do spec MD correspondente.

--- a/docs/superpowers/specs/2026-04-20-v0130-query-informada-negacoes-design.md
+++ b/docs/superpowers/specs/2026-04-20-v0130-query-informada-negacoes-design.md
@@ -4,7 +4,7 @@
 **Issue principal:** [#8](https://github.com/mencoding/maestra-ai/issues/8)
 **Issue de backlog:** [#13](https://github.com/mencoding/maestra-ai/issues/13) (itens rejeitados por YAGNI imediato)
 **Autor:** Léo + Claude (brainstorm síncrono)
-**Status:** approved — aguardando writing-plans
+**Status:** approved | **Implementado:** 2026-04-21 (branch `feat/issue-8-v0130-query-informada-negacoes`, commits `6fbca0e..0265af2`, suite 891 passed)
 
 ---
 
@@ -55,8 +55,9 @@ Três unidades novas + duas modificadas. Todas isoladas e testáveis isoladament
    - Constantes centralizadas: `POSITIVE_MARKERS`, `NEGATIVE_MARKERS`, `META_TAGS`.
 
 2. **`ParsedContext`** — dataclass frozen, definida em `context_parser.py`.
-   - Campos: `text: str`, `positive: tuple[str, ...]`, `negative: tuple[str, ...]`, `artists_hint: tuple[str, ...]`, `bpm: dict | None`.
+   - Campos: `text: str`, `positive: tuple[str, ...]`, `negative: tuple[str, ...]`, `artists_hint: tuple[str, ...]`, `bpm: BpmRange | None`.
    - Frozen → hashable, seguro pra cache.
+   - **Nota (T4.5):** campo `bpm` é `BpmRange` (não `dict`) para garantir hashability. Ver seção "Divergências implementadas vs spec original".
 
 3. **`core/external/tag_filter.py`** — helper puro.
    - `filter_lastfm_tags(raw: list[dict], *, top_n: int = 10) -> set[str]`.
@@ -101,17 +102,32 @@ META_TAGS = frozenset({
     "music", "cool", "nice",
 })
 
+# T4.5: BpmRange é frozen dataclass (em vez de dict) para garantir hashability
+# do ParsedContext. parse() ainda aceita dict via BpmRange.from_any().
+@dataclass(frozen=True)
+class BpmRange:
+    min: int | None = None
+    max: int | None = None
+
+    @classmethod
+    def from_any(cls, value: "BpmRange | dict | None") -> "BpmRange | None":
+        """Aceita BpmRange, dict com keys min/max, ou None. Normaliza para BpmRange."""
+        ...
+
 @dataclass(frozen=True)
 class ParsedContext:
     text: str
     positive: tuple[str, ...] = ()
     negative: tuple[str, ...] = ()
     artists_hint: tuple[str, ...] = ()
-    bpm: dict | None = None
+    bpm: BpmRange | None = None  # T4.5: era dict | None; agora BpmRange para hashability
 
-def parse(text: str, bpm: dict | None = None) -> ParsedContext:
+def parse(text: str, bpm: "BpmRange | dict | None" = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre. Puro, idempotente,
-    determinístico. Nenhum I/O, nenhum logging."""
+    determinístico. Nenhum I/O, nenhum logging.
+
+    `bpm` aceita dict {min, max}, BpmRange ou None (ergonomia para callers
+    que passam o dict do disco); normalizado para BpmRange internamente."""
 ```
 
 **Regras de parsing:**
@@ -364,6 +380,43 @@ Cada camada: teste primeiro, red confirmado, fix, green. Se camada N não for te
 2. Implementação em branch `feat/issue-8-query-informada-negacoes` baseada em `main` pós-merge das PRs #11, #12.
 3. Release `v0.13.0` (semver minor — novo comportamento visível, sem breaking change).
 4. CHANGELOG entry referenciando #8 como fechado e #13 como aberto pra v0.14+.
+
+## Divergências implementadas vs spec original
+
+Detectadas durante execução (commit T4.5 `4676df6`). Docs atualizados em 2026-04-21.
+
+### 1. `BpmRange` dataclass (substitui `dict`)
+
+Spec original definiu `bpm: dict | None` em `ParsedContext`. Durante implementação,
+identificou-se que `dict` quebra hashability de frozen dataclasses (o dict é mutável e
+não é hashável). Fix: novo `BpmRange(frozen=True, min: int | None, max: int | None)` com
+classmethod `from_any()` que aceita `BpmRange | dict | None`. Callers que passam dict do
+disco (ex: `ContextState.parsed()`) continuam funcionando sem mudança na camada de
+persistência.
+
+Impacto: `_build_informed_query` usa `parsed.bpm.min` / `parsed.bpm.max` (atributo),
+não `parsed.bpm.get("min")` / `parsed.bpm.get("max")` (dict API).
+
+### 2. Artist não vaza para `positive` (fix de parse)
+
+Spec original não especificou o comportamento de `_extract_after_marker` quando o rest
+começa com letra maiúscula. Na prática, `parse("tipo The HU")` colocava `"the"` em
+`positive` (o primeiro token do rest normalizado, casefold). Fix: `_extract_after_marker`
+foi refatorado para `_extract_after_marker_pair`, que devolve `(rest_norm, rest_orig)`.
+A decisão positive vs artists usa o case ORIGINAL do primeiro token: só cai em `positive`
+se começar com minúsculo no texto cru. Resultado: `"tipo The HU"` → `artists_hint=("The HU",)`,
+`positive=()` (correto).
+
+### 3. Shape real de `lastfm.top_tags` no cache (list[str])
+
+Spec assumiu que `lastfm.top_tags` no cache externo seria `list[dict]` com keys `name` e
+`count` (shape da API Last.fm). O cache real (`external_cache.json` v2) armazena `list[str]`
+(nomes apenas, sem count), pois `LastfmSource._artist_top_tags` flattena antes de gravar.
+Fix em `_track_tags`: wrappa strings no shape `[{"name": s, "count": 0}]` antes de passar
+para `filter_lastfm_tags`. O corte `top_n` por count vira no-op, mas o filtro de meta-tags
+(décadas, países, avaliativos) continua funcionando. Documentado no docstring do método.
+
+---
 
 ## Referências
 

--- a/packages/maestra-ai/pyproject.toml
+++ b/packages/maestra-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestra-ai"
-version = "0.12.0"
+version = "0.13.0"
 description = "Spotify controller with context-aware curation for AI agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/maestra-ai/src/maestra_ai/core/context.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context.py
@@ -7,6 +7,7 @@ import json
 import os
 from datetime import datetime, timedelta
 
+from maestra_ai.core.context_parser import BpmRange, ParsedContext, parse as _parse_context
 from maestra_ai.core.storage import atomic_write_json
 
 _BPM_MIN = 30
@@ -47,6 +48,7 @@ class ContextState:
         self.path = path
 
     def set(self, text: str, bpm: dict | None = None, ttl_minutes: int = 120):
+        self._parsed_cache = None
         current = self._read_raw()
         previous = _normalize_context_field((current or {}).get("context"))
 
@@ -73,6 +75,7 @@ class ContextState:
         return self.set(previous["text"], bpm=bpm)
 
     def clear_bpm(self):
+        self._parsed_cache = None
         current = self._read_raw() or {}
         previous = _normalize_context_field(current.get("context"))
         if not previous["text"]:
@@ -102,9 +105,31 @@ class ContextState:
         return data
 
     def clear(self):
+        self._parsed_cache = None
         if os.path.exists(self.path):
             os.remove(self.path)
         return {"status": "cleared"}
+
+    def parsed(self) -> ParsedContext | None:
+        """Retorna ParsedContext do estado atual, memoizado por (text, bpm).
+
+        None se não há contexto ativo (show() retorna None, ou TTL expirou).
+        Identidade preservada entre chamadas idempotentes.
+        """
+        data = self.show()
+        if not data:
+            return None
+        ctx = data.get("context") or {}
+        text = ctx.get("text") or ""
+        bpm_raw = ctx.get("bpm")
+        bpm = BpmRange.from_any(bpm_raw)
+
+        cache = getattr(self, "_parsed_cache", None)
+        if cache is not None and cache[0] == text and cache[1].bpm == bpm:
+            return cache[1]
+        parsed = _parse_context(text, bpm=bpm)
+        self._parsed_cache = (text, parsed)
+        return parsed
 
     def _read_raw(self) -> dict | None:
         if not os.path.exists(self.path):

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -8,6 +8,7 @@ Issue #8, v0.13.
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 
 
@@ -31,6 +32,11 @@ class ParsedContext:
     negative: tuple[str, ...] = ()
     artists_hint: tuple[str, ...] = ()
     bpm: dict | None = None
+
+
+def _normalize_for_match(text: str) -> str:
+    """NFKC + casefold pra match determinístico, invariante a acento/case."""
+    return unicodedata.normalize("NFKC", text).casefold()
 
 
 def _split_clauses(text: str) -> list[str]:
@@ -63,31 +69,40 @@ def parse(text: str, bpm: dict | None = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre.
 
     Puro, idempotente, determinístico. Nenhum I/O, nenhum logging.
+    O matching é feito sobre texto normalizado (NFKC + casefold); o texto
+    original é preservado em ParsedContext.text.
     """
     if not text:
         return ParsedContext(text="", bpm=bpm)
+
+    # Markers normalizados (computados uma vez para comparação)
+    neg_markers_norm = tuple(_normalize_for_match(m) for m in NEGATIVE_MARKERS)
+    pos_markers_norm = tuple(_normalize_for_match(m) for m in POSITIVE_MARKERS)
 
     negative: list[str] = []
     positive: list[str] = []
     artists_hint: list[str] = []
 
     for clause in _split_clauses(text):
-        neg_rest = _extract_after_marker(clause, NEGATIVE_MARKERS)
-        pos_rest = _extract_after_marker(clause, POSITIVE_MARKERS)
+        clause_norm = _normalize_for_match(clause)
+
+        neg_rest_norm = _extract_after_marker(clause_norm, neg_markers_norm)
+        pos_rest_norm = _extract_after_marker(clause_norm, pos_markers_norm)
 
         # Negativos têm prioridade sobre positivos em caso de conflito
-        if neg_rest is not None:
-            first = neg_rest.split()[0] if neg_rest.split() else ""
+        if neg_rest_norm is not None:
+            first = neg_rest_norm.split()[0] if neg_rest_norm.split() else ""
             if first:
                 negative.append(first)
             continue  # não processa positivo nesta cláusula
 
-        if pos_rest is not None:
-            # Para artists_hint: coleta palavras capitalizadas da cláusula
-            caps = _extract_artists(clause, pos_rest)
+        if pos_rest_norm is not None:
+            # Para artists_hint: coleta palavras capitalizadas do clause ORIGINAL
+            # (clause_norm perde as maiúsculas; artistas precisam de capitalização)
+            caps = _extract_artists(clause, pos_rest_norm)
             artists_hint.extend(caps)
-            # Para positive: primeiro token do rest (pode ser "rock", "lo-fi", etc.)
-            first = pos_rest.split()[0] if pos_rest.split() else ""
+            # Para positive: primeiro token do rest normalizado
+            first = pos_rest_norm.split()[0] if pos_rest_norm.split() else ""
             if first and first[0].islower():
                 positive.append(first)
 

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -26,12 +26,33 @@ POSITIVE_MARKERS: tuple[str, ...] = (
 
 
 @dataclass(frozen=True)
+class BpmRange:
+    """Intervalo de BPM. Frozen pra ser hashable e coabitar com ParsedContext
+    em caches por valor."""
+    min: int | None = None
+    max: int | None = None
+
+    @classmethod
+    def from_any(cls, value: "BpmRange | dict | None") -> "BpmRange | None":
+        """Aceita BpmRange, dict com keys min/max, ou None. Normaliza para
+        BpmRange. Usado por parse() e por ContextState.parsed() para ingress
+        do formato {min, max} persistido em disco."""
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return cls(min=value.get("min"), max=value.get("max"))
+        raise TypeError(f"unsupported bpm type: {type(value).__name__}")
+
+
+@dataclass(frozen=True)
 class ParsedContext:
     text: str
     positive: tuple[str, ...] = ()
     negative: tuple[str, ...] = ()
     artists_hint: tuple[str, ...] = ()
-    bpm: dict | None = None
+    bpm: BpmRange | None = None
 
 
 def _normalize_for_match(text: str) -> str:
@@ -44,38 +65,54 @@ def _split_clauses(text: str) -> list[str]:
     return [c.strip() for c in re.split(r"[,.;]", text) if c.strip()]
 
 
-def _extract_after_marker(clause: str, markers: tuple[str, ...]) -> str | None:
-    """Se clause começa com um marker, retorna o resto. Caso contrário, None."""
-    for marker in markers:
-        idx = clause.find(marker)
-        if idx >= 0:
-            return clause[idx + len(marker):].strip()
+def _extract_after_marker_pair(
+    clause: str,
+    clause_norm: str,
+    markers_norm: tuple[str, ...],
+) -> tuple[str, str] | None:
+    """Tenta matchar algum marker (normalizado) em clause_norm e retorna
+    (rest_norm, rest_original) stripped. Retorna None se nenhum marker bate.
+
+    Pressupõe len(clause) == len(clause_norm), válido para ASCII e PT-BR
+    (NFKC e casefold preservam comprimento para esses ranges). Se a
+    invariante for violada (ex: 'İ'.casefold() = 'i̇', 2 chars), o fallback
+    silencioso é usar clause_norm para ambos — sem crash, degradação leve.
+    """
+    for marker in markers_norm:
+        idx = clause_norm.find(marker)
+        if idx < 0:
+            continue
+        rest_start = idx + len(marker)
+        if len(clause) == len(clause_norm):
+            return clause_norm[rest_start:].strip(), clause[rest_start:].strip()
+        # Fallback defensivo: índices não batem, usa o normalizado pros dois
+        return clause_norm[rest_start:].strip(), clause_norm[rest_start:].strip()
     return None
 
 
-def _extract_artists(original_clause: str, term: str) -> list[str]:
-    """Se o term extraído começa com maiúscula(s), considera artista.
+def _extract_artists(original_clause: str) -> list[str]:
+    """Extrai sequências capitalizadas do clause original (não normalizado).
 
-    Recebe o original_clause (não normalizado) e o term já extraído.
-    Procura a sequência capitalizada começando na posição do term.
+    Regex: sequência de palavras capitalizadas (cada uma começa maiúscula).
     """
-    # Regex: sequência de palavras capitalizadas (cada uma começa maiúscula)
     pattern = r"\b([A-Z][A-Za-z]*(?:\s+[A-Z][A-Za-z]*)*)\b"
     matches = re.findall(pattern, original_clause)
     return [m for m in matches if len(m) > 1]
 
 
-def parse(text: str, bpm: dict | None = None) -> ParsedContext:
+def parse(text: str, bpm: "BpmRange | dict | None" = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre.
 
     Puro, idempotente, determinístico. Nenhum I/O, nenhum logging.
-    O matching é feito sobre texto normalizado (NFKC + casefold); o texto
-    original é preservado em ParsedContext.text.
-    """
-    if not text:
-        return ParsedContext(text="", bpm=bpm)
 
-    # Markers normalizados (computados uma vez para comparação)
+    `bpm` aceita dict {min, max}, BpmRange ou None; normalizado para
+    BpmRange internamente para preservar hashability do ParsedContext.
+    """
+    bpm_norm = BpmRange.from_any(bpm)
+
+    if not text:
+        return ParsedContext(text="", bpm=bpm_norm)
+
     neg_markers_norm = tuple(_normalize_for_match(m) for m in NEGATIVE_MARKERS)
     pos_markers_norm = tuple(_normalize_for_match(m) for m in POSITIVE_MARKERS)
 
@@ -86,30 +123,29 @@ def parse(text: str, bpm: dict | None = None) -> ParsedContext:
     for clause in _split_clauses(text):
         clause_norm = _normalize_for_match(clause)
 
-        neg_rest_norm = _extract_after_marker(clause_norm, neg_markers_norm)
-        pos_rest_norm = _extract_after_marker(clause_norm, pos_markers_norm)
+        neg = _extract_after_marker_pair(clause, clause_norm, neg_markers_norm)
+        if neg is not None:
+            _rest_norm, rest_orig = neg
+            parts = rest_orig.split()
+            if parts:
+                negative.append(parts[0].casefold())
+            continue
 
-        # Negativos têm prioridade sobre positivos em caso de conflito
-        if neg_rest_norm is not None:
-            first = neg_rest_norm.split()[0] if neg_rest_norm.split() else ""
-            if first:
-                negative.append(first)
-            continue  # não processa positivo nesta cláusula
-
-        if pos_rest_norm is not None:
-            # Para artists_hint: coleta palavras capitalizadas do clause ORIGINAL
-            # (clause_norm perde as maiúsculas; artistas precisam de capitalização)
-            caps = _extract_artists(clause, pos_rest_norm)
+        pos = _extract_after_marker_pair(clause, clause_norm, pos_markers_norm)
+        if pos is not None:
+            _rest_norm, rest_orig = pos
+            caps = _extract_artists(rest_orig)
             artists_hint.extend(caps)
-            # Para positive: primeiro token do rest normalizado
-            first = pos_rest_norm.split()[0] if pos_rest_norm.split() else ""
-            if first and first[0].islower():
-                positive.append(first)
+            parts = rest_orig.split()
+            # Só vira positive se primeiro token começa com minúscula no
+            # texto original. Capitalizado = artist, tratado em _extract_artists.
+            if parts and parts[0] and parts[0][0].islower():
+                positive.append(parts[0].casefold())
 
     return ParsedContext(
         text=text,
         positive=tuple(positive),
         negative=tuple(negative),
         artists_hint=tuple(artists_hint),
-        bpm=bpm,
+        bpm=bpm_norm,
     )

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -7,19 +7,15 @@ Issue #8, v0.13.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import re
+from dataclasses import dataclass
+
+
+NEGATIVE_MARKERS: tuple[str, ...] = ("evitar ", "sem ", "não ", "nao ")
 
 
 @dataclass(frozen=True)
 class ParsedContext:
-    """Estrutura derivada do texto cru do contexto.
-
-    - text: texto original preservado (sem normalização) para log/debug.
-    - positive: termos após marker positivo ("tipo X", "como Y").
-    - negative: termos após marker negativo ("evitar X", "sem Y").
-    - artists_hint: nomes próprios capitalizados após marker positivo.
-    - bpm: objeto {min, max} repassado do ContextState.
-    """
     text: str
     positive: tuple[str, ...] = ()
     negative: tuple[str, ...] = ()
@@ -27,9 +23,39 @@ class ParsedContext:
     bpm: dict | None = None
 
 
+def _split_clauses(text: str) -> list[str]:
+    """Quebra por vírgula, ponto, ponto-e-vírgula. Retorna fragmentos limpos."""
+    return [c.strip() for c in re.split(r"[,.;]", text) if c.strip()]
+
+
+def _extract_after_marker(clause: str, markers: tuple[str, ...]) -> str | None:
+    """Se clause começa com um marker, retorna o resto. Caso contrário, None."""
+    for marker in markers:
+        idx = clause.find(marker)
+        if idx >= 0:
+            return clause[idx + len(marker):].strip()
+    return None
+
+
 def parse(text: str, bpm: dict | None = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre.
 
     Puro, idempotente, determinístico. Nenhum I/O, nenhum logging.
     """
-    return ParsedContext(text=text or "", bpm=bpm)
+    if not text:
+        return ParsedContext(text="", bpm=bpm)
+
+    negative: list[str] = []
+    for clause in _split_clauses(text):
+        rest = _extract_after_marker(clause, NEGATIVE_MARKERS)
+        if rest:
+            # Pega o primeiro termo (primeira "palavra-chave" do rest)
+            first_token = rest.split()[0] if rest.split() else ""
+            if first_token:
+                negative.append(first_token)
+
+    return ParsedContext(
+        text=text,
+        negative=tuple(negative),
+        bpm=bpm,
+    )

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -13,6 +13,16 @@ from dataclasses import dataclass
 
 NEGATIVE_MARKERS: tuple[str, ...] = ("evitar ", "sem ", "não ", "nao ")
 
+# Ordenados do mais longo para o mais curto: "algo tipo " deve ser testado
+# antes de "tipo " para evitar match parcial incorreto em "algo tipo X".
+POSITIVE_MARKERS: tuple[str, ...] = (
+    "algo tipo ",
+    "parecido com ",
+    "tipo ",
+    "como ",
+    "mais ",
+)
+
 
 @dataclass(frozen=True)
 class ParsedContext:
@@ -37,6 +47,18 @@ def _extract_after_marker(clause: str, markers: tuple[str, ...]) -> str | None:
     return None
 
 
+def _extract_artists(original_clause: str, term: str) -> list[str]:
+    """Se o term extraído começa com maiúscula(s), considera artista.
+
+    Recebe o original_clause (não normalizado) e o term já extraído.
+    Procura a sequência capitalizada começando na posição do term.
+    """
+    # Regex: sequência de palavras capitalizadas (cada uma começa maiúscula)
+    pattern = r"\b([A-Z][A-Za-z]*(?:\s+[A-Z][A-Za-z]*)*)\b"
+    matches = re.findall(pattern, original_clause)
+    return [m for m in matches if len(m) > 1]
+
+
 def parse(text: str, bpm: dict | None = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre.
 
@@ -46,16 +68,33 @@ def parse(text: str, bpm: dict | None = None) -> ParsedContext:
         return ParsedContext(text="", bpm=bpm)
 
     negative: list[str] = []
+    positive: list[str] = []
+    artists_hint: list[str] = []
+
     for clause in _split_clauses(text):
-        rest = _extract_after_marker(clause, NEGATIVE_MARKERS)
-        if rest:
-            # Pega o primeiro termo (primeira "palavra-chave" do rest)
-            first_token = rest.split()[0] if rest.split() else ""
-            if first_token:
-                negative.append(first_token)
+        neg_rest = _extract_after_marker(clause, NEGATIVE_MARKERS)
+        pos_rest = _extract_after_marker(clause, POSITIVE_MARKERS)
+
+        # Negativos têm prioridade sobre positivos em caso de conflito
+        if neg_rest is not None:
+            first = neg_rest.split()[0] if neg_rest.split() else ""
+            if first:
+                negative.append(first)
+            continue  # não processa positivo nesta cláusula
+
+        if pos_rest is not None:
+            # Para artists_hint: coleta palavras capitalizadas da cláusula
+            caps = _extract_artists(clause, pos_rest)
+            artists_hint.extend(caps)
+            # Para positive: primeiro token do rest (pode ser "rock", "lo-fi", etc.)
+            first = pos_rest.split()[0] if pos_rest.split() else ""
+            if first and first[0].islower():
+                positive.append(first)
 
     return ParsedContext(
         text=text,
+        positive=tuple(positive),
         negative=tuple(negative),
+        artists_hint=tuple(artists_hint),
         bpm=bpm,
     )

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -1,0 +1,35 @@
+"""Parser puro de contexto musical livre para ParsedContext estruturada.
+
+Módulo sem dependências do core — só stdlib. Consumido por ContextState
+(memoização) e por Curator (_build_informed_query, _apply_negative_filter).
+
+Issue #8, v0.13.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ParsedContext:
+    """Estrutura derivada do texto cru do contexto.
+
+    - text: texto original preservado (sem normalização) para log/debug.
+    - positive: termos após marker positivo ("tipo X", "como Y").
+    - negative: termos após marker negativo ("evitar X", "sem Y").
+    - artists_hint: nomes próprios capitalizados após marker positivo.
+    - bpm: objeto {min, max} repassado do ContextState.
+    """
+    text: str
+    positive: tuple[str, ...] = ()
+    negative: tuple[str, ...] = ()
+    artists_hint: tuple[str, ...] = ()
+    bpm: dict | None = None
+
+
+def parse(text: str, bpm: dict | None = None) -> ParsedContext:
+    """Extrai intenção estruturada de texto livre.
+
+    Puro, idempotente, determinístico. Nenhum I/O, nenhum logging.
+    """
+    return ParsedContext(text=text or "", bpm=bpm)

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -97,12 +97,25 @@ class Curator:
     def curate(self, context, count=5, exclude_uris=None, exclude_artists=None, max_per_artist=None, enhance_candidates=True):
         """Gera lista de faixas para um contexto.
 
+        `context` aceita `str` ou `ParsedContext` (duck-typing via `hasattr`).
+        Quando `ParsedContext`, pulamos o parse (evita duplicar trabalho do caller).
+
         Retorna tupla (tracks, queries_used, sources_used).
         tracks: lista de dicts com track, artist, uri.
         queries_used: lista de queries efetivamente usadas.
         sources_used: lista de fontes externas ativas.
         """
-        context = self._normalize_context(context)
+        from maestra_ai.core.context_parser import parse as parse_context_text
+        from maestra_ai.core.scoring import anti_tag_penalty
+
+        # Normaliza: aceita `str` ou `ParsedContext` (duck-typing)
+        if hasattr(context, "text"):
+            parsed = context
+            context_text = parsed.text
+        else:
+            context_text = self._normalize_context(context)
+            parsed = parse_context_text(context_text, bpm=self._active_bpm_target())
+
         queries_used: list[str] = []
         candidates: list[dict] = []
         excluded = set(exclude_uris or [])
@@ -119,24 +132,21 @@ class Curator:
                 seen.add(r["uri"])
                 candidates.append(r)
 
-        # 1) Query informada — parseia contexto pra ParsedContext antes.
-        # Integração completa (negative filter, degraded) chega no T11.
-        from maestra_ai.core.context_parser import parse as parse_context_text
-        parsed = parse_context_text(context, bpm=self._active_bpm_target())
+        # 1) Query informada a partir do ParsedContext
         informed = self._build_informed_query(parsed)
         if informed:
             _search_and_collect(informed)
 
         # 2) Fallback SEMANTIC_MAP se abaixo do mínimo
         if len(candidates) < MIN_CANDIDATES:
-            for q in self._resolve_queries(context):
+            for q in self._resolve_queries(context_text):
                 if q in queries_used:
                     continue
                 _search_and_collect(q)
                 if len(candidates) >= MIN_CANDIDATES:
                     break
 
-        # v0.12.0: enrich candidates com metadata externa antes do re-rank.
+        # 3) v0.12.0: enrich candidates com metadata externa antes do re-rank.
         # Skip se usuário passou --no-enhance (enhance_candidates=False).
         if enhance_candidates and candidates:
             from maestra_ai.core.external import default_enhancer
@@ -157,12 +167,17 @@ class Curator:
                 except Exception as e:
                     logger.warning("Enhancement de candidatos falhou: %s", e)
 
-        # 3) Filtra rejeitadas pelo perfil de gosto (URI + context_score + artistas excluídos pelo caller)
+        # 4) Hard filter adaptativo (v0.13): remove candidatos com tag negada.
+        # Se o filtro deixar < MIN_CANDIDATES, mantém originais com degraded=True
+        # para o scoring aplicar penalty suave no re-rank.
+        candidates, degraded = self._apply_negative_filter(candidates, parsed)
+
+        # 5) Filtra rejeitadas pelo perfil de gosto (URI + context_score + artistas excluídos pelo caller)
         filtered = []
         for c in candidates:
             if self.taste.is_rejected(c["uri"]):
                 continue
-            if self.taste.context_score(c["uri"], context) < 0:
+            if self.taste.context_score(c["uri"], context_text) < 0:
                 continue
             if c["artist"] in excluded_artists:
                 continue
@@ -171,18 +186,25 @@ class Curator:
         # Filtra por artistas rejeitados no perfil (delegação ao TasteProfile)
         filtered = self.taste.filter_with_artist_info(filtered)
 
-        # 4) Re-rank por compose_score (taste + decade + tag + bpm ponderados)
+        # 6) Re-rank por compose_score (taste + decade + tag + bpm ponderados).
+        # Quando degraded=True, soma anti_tag_penalty para afastar candidatos com tag negada.
         from maestra_ai.core.config import load_and_migrate, load_curate_weights
         cfg = load_and_migrate()
         weights = load_curate_weights(cfg)
         has_lf = (cfg.get("external_sources") or {}).get("lastfm", {}).get("enabled", False)
+        negative_set = set(parsed.negative)
 
-        filtered.sort(
-            key=lambda c: self._compose_score_for(c, context, weights, has_lf),
-            reverse=True,
-        )
+        def _score(c):
+            base = self._compose_score_for(c, context_text, weights, has_lf)
+            if degraded and negative_set:
+                base += anti_tag_penalty(
+                    self._track_tags(c), negative_set, degraded=True,
+                )
+            return base
 
-        # 5) max_per_artist
+        filtered.sort(key=_score, reverse=True)
+
+        # 7) max_per_artist
         if max_per_artist:
             limited: list[dict] = []
             counts: dict[str, int] = {}

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -1,5 +1,9 @@
 """Curator — traduz contexto livre em buscas e retorna faixas filtradas."""
 
+# Import de módulo (não de símbolo) para permitir monkeypatch em testes de
+# `_track_tags` sem exigir patch do caminho `maestra_ai.core.external.cache`.
+from maestra_ai.core.external import cache as cache_mod
+
 # Tabela semântica: palavras-chave → queries de busca
 SEMANTIC_MAP = {
     "foco": ["lo-fi instrumental", "ambient study", "minimal piano", "post-rock instrumental"],
@@ -175,13 +179,42 @@ class Curator:
         return set()
 
     def _track_tags(self, track: dict) -> set[str]:
-        """Tags do artista via cache external (MB + LF se presente).
+        """Tags do artista/track via cache external.
 
-        v0.10.0-alpha.1: simplificado — retorna vazio (contribui 0 no score
-        via tag_similarity). Integração rica com enhancement cache virá
-        quando houver demanda de calibração real.
+        Merge MB (canônico) + LF (filtrado via tag_filter). Retorna set vazio
+        quando o cache não tem entrada pro URI ou nenhuma source populou.
+
+        Nota sobre a shape real do cache (external_cache.json v2):
+        - `musicbrainz.tags` é `list[str]` — tags canônicas entram direto.
+        - `lastfm.top_tags` é `list[str]` (nomes só, sem count), pois o
+          `LastfmSource` flattena via `_artist_top_tags`. Wrappamos em
+          `[{"name": s, "count": 0}]` para reaproveitar `filter_lastfm_tags`
+          (remoção de meta-tags). O corte top_n por count vira no-op, mas o
+          filtro de ruído (décadas, avaliativos, países) continua valendo.
         """
-        return set()
+        from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+
+        uri = track.get("uri") or ""
+        if not uri:
+            return set()
+        cached = cache_mod.get_track(uri)
+        if not cached:
+            return set()
+
+        tags: set[str] = set()
+
+        # MusicBrainz: tags já canônicas, union direto (lowercased).
+        mb = cached.get("musicbrainz") or {}
+        mb_tags = mb.get("tags") or []
+        tags.update(t.lower() for t in mb_tags if t)
+
+        # Last.fm: wrap strings no shape esperado pelo filtro; garante dedup/filtro.
+        lf = cached.get("lastfm") or {}
+        lf_raw = lf.get("top_tags") or []
+        lf_wrapped = [{"name": t, "count": 0} for t in lf_raw if t]
+        tags.update(filter_lastfm_tags(lf_wrapped))
+
+        return tags
 
     def _context_tags(self, context: str) -> set[str]:
         """Tags do contexto derivadas de MOOD_TAG_KEYWORDS."""

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -53,14 +53,40 @@ class Curator:
         self.controller = controller
         self.taste = taste
 
-    def _build_informed_query(self, context: str) -> str | None:
-        """Monta query "{tag_dominante} {mood} {decade}" a partir de tags do perfil.
+    def _build_informed_query(self, parsed) -> str | None:
+        """Query informada a partir de ParsedContext + taste.
 
-        v0.10.0-alpha.1: stub mínimo (retorna None). Cascade cai direto no
-        SEMANTIC_MAP. A derivação real via conjunto_positivo virá quando
-        houver uso suficiente para calibrar.
+        Formato: "{artist_hint_ou_top_taste} {positive} {bpm_qualifier}".
+        Skip top taste que aparecem em negative. Retorna None se nenhum sinal.
         """
-        return None
+        negative = set(parsed.negative) if parsed.negative else set()
+
+        # Parte 1: artista (artist_hint tem prioridade sobre top taste)
+        artist_part: str | None = None
+        if parsed.artists_hint:
+            artist_part = parsed.artists_hint[0]
+        else:
+            # Top preferred artist que não bata com negative
+            top = self.taste.get_preferred_artists() or []
+            for a in top[:5]:
+                if not any(n in a.lower() for n in negative):
+                    artist_part = a
+                    break
+
+        # Parte 2: positive (primeiro termo, se houver)
+        positive_part = parsed.positive[0] if parsed.positive else None
+
+        # Parte 3: bpm qualifier — usa atributos do BpmRange (não dict)
+        bpm_part = None
+        if parsed.bpm is not None and parsed.bpm.min is not None and parsed.bpm.max is not None:
+            mid = (parsed.bpm.min + parsed.bpm.max) // 2
+            bpm_part = f"{mid}bpm"
+
+        # Se nenhuma parte produziu sinal, retorna None
+        parts = [p for p in (artist_part, positive_part, bpm_part) if p]
+        if not parts:
+            return None
+        return " ".join(parts)
 
     def _active_sources(self) -> list[str]:
         from maestra_ai.core.config import load_and_migrate
@@ -93,8 +119,11 @@ class Curator:
                 seen.add(r["uri"])
                 candidates.append(r)
 
-        # 1) Query informada
-        informed = self._build_informed_query(context)
+        # 1) Query informada — parseia contexto pra ParsedContext antes.
+        # Integração completa (negative filter, degraded) chega no T11.
+        from maestra_ai.core.context_parser import parse as parse_context_text
+        parsed = parse_context_text(context, bpm=self._active_bpm_target())
+        informed = self._build_informed_query(parsed)
         if informed:
             _search_and_collect(informed)
 

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -1,8 +1,12 @@
 """Curator — traduz contexto livre em buscas e retorna faixas filtradas."""
 
+import logging
+
 # Import de módulo (não de símbolo) para permitir monkeypatch em testes de
 # `_track_tags` sem exigir patch do caminho `maestra_ai.core.external.cache`.
 from maestra_ai.core.external import cache as cache_mod
+
+logger = logging.getLogger(__name__)
 
 # Tabela semântica: palavras-chave → queries de busca
 SEMANTIC_MAP = {
@@ -106,8 +110,6 @@ class Curator:
         # v0.12.0: enrich candidates com metadata externa antes do re-rank.
         # Skip se usuário passou --no-enhance (enhance_candidates=False).
         if enhance_candidates and candidates:
-            import logging
-            logger = logging.getLogger(__name__)
             from maestra_ai.core.external import default_enhancer
             from maestra_ai.core.external.types import TrackInfo
 
@@ -215,6 +217,35 @@ class Curator:
         tags.update(filter_lastfm_tags(lf_wrapped))
 
         return tags
+
+    def _apply_negative_filter(
+        self,
+        candidates: list[dict],
+        parsed,  # ParsedContext — tipagem leve pra evitar import circular
+    ) -> tuple[list[dict], bool]:
+        """Hard filter removendo candidatos com tag em parsed.negative.
+
+        Se len(filtered) < MIN_CANDIDATES, retorna originais com degraded=True.
+        Caller usa degraded pra ativar anti_tag_penalty no scoring.
+        """
+        if not parsed.negative:
+            return candidates, False
+
+        negative_set = set(parsed.negative)
+        filtered = [
+            c for c in candidates
+            if not (self._track_tags(c) & negative_set)
+        ]
+
+        if len(filtered) >= MIN_CANDIDATES:
+            return filtered, False
+
+        logger.warning(
+            "hard filter on %s would leave %d candidates (< %d); "
+            "degrading to soft penalty",
+            sorted(negative_set), len(filtered), MIN_CANDIDATES,
+        )
+        return candidates, True
 
     def _context_tags(self, context: str) -> set[str]:
         """Tags do contexto derivadas de MOOD_TAG_KEYWORDS."""

--- a/packages/maestra-ai/src/maestra_ai/core/external/tag_filter.py
+++ b/packages/maestra-ai/src/maestra_ai/core/external/tag_filter.py
@@ -1,0 +1,47 @@
+"""Filtro de tags Last.fm para remover ruído (meta-tags, avaliativos).
+
+Complemento puro do enhancer. Input: lista bruta de dicts do pylast
+(cada item com keys `name` e `count`). Output: set de tags normalizadas,
+filtradas por relevância.
+
+Issue #8, v0.13.
+"""
+from __future__ import annotations
+
+
+META_TAGS: frozenset[str] = frozenset({
+    # Décadas
+    "1950s", "1960s", "1970s", "1980s", "1990s", "2000s", "2010s", "2020s",
+    # Países / nacionalidade
+    "american", "british", "french", "german", "japanese", "brazilian",
+    "italian", "spanish", "swedish", "norwegian", "canadian", "australian",
+    "irish", "finnish", "dutch", "polish", "russian", "chinese", "korean",
+    # Avaliativos / vazios
+    "awesome", "favorite", "favourite", "good", "great", "amazing",
+    "best", "love", "loved", "cool", "nice", "music", "songs", "song",
+    "seen live",
+})
+
+
+def filter_lastfm_tags(raw: list[dict], *, top_n: int = 10) -> set[str]:
+    """Retorna set de tags significativas (normalizadas, sem meta-tags).
+
+    - `raw`: lista de dicts com `name` (obrigatório) e `count` (opcional, default 0).
+    - `top_n`: corta pelo top `top_n` ordenado por `count` desc depois do filter.
+    """
+    if not raw:
+        return set()
+
+    # Normaliza (lowercase + strip) e filtra meta-tags
+    normalized = []
+    for item in raw:
+        name = (item.get("name") or "").strip().lower()
+        if not name or name in META_TAGS:
+            continue
+        count = item.get("count") or 0
+        normalized.append((name, count))
+
+    # Ordena por count desc, pega top_n, deduplica pelo set
+    normalized.sort(key=lambda x: x[1], reverse=True)
+    top = normalized[:top_n]
+    return {name for name, _ in top}

--- a/packages/maestra-ai/src/maestra_ai/core/scoring.py
+++ b/packages/maestra-ai/src/maestra_ai/core/scoring.py
@@ -1,9 +1,16 @@
 """Componentes e composição do score de curadoria v0.10.
 
 Componentes puros (tag_similarity, decade_match, bpm_proximity) +
-effective_weights (degradação graciosa quando sinal falta) + compose_score.
+effective_weights (degradação graciosa quando sinal falta) + compose_score +
+anti_tag_penalty (penalidade para tags negadas em modo degraded).
 """
 from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Pesos de penalidade
+# ---------------------------------------------------------------------------
+
+W_ANTI_TAG: float = 0.4  # calibrar após primeira semana de uso (issue #13)
 
 
 def tag_similarity(tags_a: set[str], tags_b: set[str]) -> float:
@@ -93,3 +100,27 @@ def compose_score(
         + weights["decade"] * decade
         + weights["bpm"]    * bpm
     )
+
+
+def anti_tag_penalty(
+    track_tags: set[str],
+    negative_tags: set[str],
+    *,
+    degraded: bool,
+) -> float:
+    """Penalty negativa para candidatos com tag negada, ativa só em modo degraded.
+
+    Retorna 0.0 quando:
+    - degraded=False (hard filter já tratou, não penalizar duas vezes).
+    - Sem overlap entre track_tags e negative_tags.
+
+    Escala: proporcional ao overlap, limitado em 3 tags pra evitar crescimento
+    descontrolado. Fórmula: -W_ANTI_TAG * min(overlap_count, 3) / 3.
+    """
+    if not degraded or not negative_tags:
+        return 0.0
+    overlap = len(track_tags & negative_tags)
+    if overlap == 0:
+        return 0.0
+    capped = min(overlap, 3)
+    return -W_ANTI_TAG * (capped / 3)

--- a/packages/maestra-ai/tests/unit/external/test_tag_filter.py
+++ b/packages/maestra-ai/tests/unit/external/test_tag_filter.py
@@ -1,0 +1,50 @@
+"""Testes do filtro de tags Last.fm (issue #8)."""
+from __future__ import annotations
+
+
+def test_remove_tag_de_decada():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [{"name": "2010s", "count": 100}, {"name": "folk metal", "count": 50}]
+    assert filter_lastfm_tags(raw) == {"folk metal"}
+
+
+def test_remove_tag_de_pais():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [{"name": "brazilian", "count": 200}, {"name": "mpb", "count": 90}]
+    assert filter_lastfm_tags(raw) == {"mpb"}
+
+
+def test_remove_tag_avaliativa():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [{"name": "awesome", "count": 500}, {"name": "shoegaze", "count": 100}]
+    assert filter_lastfm_tags(raw) == {"shoegaze"}
+
+
+def test_top_n_corta_por_popularidade():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [
+        {"name": "tag1", "count": 100},
+        {"name": "tag2", "count": 90},
+        {"name": "tag3", "count": 80},
+        {"name": "tag4", "count": 70},
+    ]
+    assert filter_lastfm_tags(raw, top_n=2) == {"tag1", "tag2"}
+
+
+def test_normaliza_case():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [{"name": "Folk Metal", "count": 50}, {"name": "folk metal", "count": 40}]
+    result = filter_lastfm_tags(raw)
+    # Depois da normalização, os dois viram "folk metal" e viram um único set
+    assert result == {"folk metal"}
+
+
+def test_input_vazio():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    assert filter_lastfm_tags([]) == set()
+
+
+def test_item_sem_count_trata_como_zero():
+    from maestra_ai.core.external.tag_filter import filter_lastfm_tags
+    raw = [{"name": "shoegaze"}]  # sem count
+    assert filter_lastfm_tags(raw) == {"shoegaze"}

--- a/packages/maestra-ai/tests/unit/test_context.py
+++ b/packages/maestra-ai/tests/unit/test_context.py
@@ -83,3 +83,40 @@ def test_show_ignora_ttl_nulo(tmp_path):
     state = ContextState(str(path))
 
     assert state.show()["context"]["text"] == "foco"
+
+
+class TestParsed:
+    def test_parsed_retorna_none_quando_sem_contexto(self, tmp_path):
+        state = ContextState(str(tmp_path / "ctx.json"))
+        assert state.parsed() is None
+
+    def test_parsed_retorna_parsed_context_apos_set(self, tmp_path):
+        from maestra_ai.core.context_parser import ParsedContext
+        state = ContextState(str(tmp_path / "ctx.json"))
+        state.set("metal tribal evitar ambient")
+        p = state.parsed()
+        assert isinstance(p, ParsedContext)
+        assert "ambient" in p.negative
+
+    def test_parsed_memoiza_entre_chamadas(self, tmp_path):
+        state = ContextState(str(tmp_path / "ctx.json"))
+        state.set("foco")
+        p1 = state.parsed()
+        p2 = state.parsed()
+        assert p1 is p2  # identidade preservada por memoização
+
+    def test_parsed_invalida_apos_novo_set(self, tmp_path):
+        state = ContextState(str(tmp_path / "ctx.json"))
+        state.set("foco")
+        p1 = state.parsed()
+        state.set("energia")
+        p2 = state.parsed()
+        assert p1 is not p2
+        assert p2.text == "energia"
+
+    def test_parsed_repass_bpm_do_context(self, tmp_path):
+        from maestra_ai.core.context_parser import BpmRange
+        state = ContextState(str(tmp_path / "ctx.json"))
+        state.set("foco", bpm={"min": 60, "max": 90})
+        p = state.parsed()
+        assert p.bpm == BpmRange(min=60, max=90)

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -90,3 +90,25 @@ class TestArtistsHint:
         from maestra_ai.core.context_parser import parse
         p = parse("tipo rock")
         assert p.artists_hint == ()
+
+
+class TestNormalizacao:
+    def test_nao_e_nao_sao_equivalentes(self):
+        from maestra_ai.core.context_parser import parse
+        p1 = parse("não acústico")
+        p2 = parse("nao acustico")
+        # Ambos devem pegar o negativo
+        assert len(p1.negative) == 1
+        assert len(p2.negative) == 1
+
+    def test_maiusculas_nao_afetam_marker(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("EVITAR jazz")
+        assert "jazz" in p.negative
+
+    def test_acentos_preservados_no_term_extraido(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("sem distração")
+        # O term pode estar normalizado ou preservado — o importante é
+        # que o match funcionou e o term é recuperável
+        assert len(p.negative) == 1

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -91,6 +91,70 @@ class TestArtistsHint:
         p = parse("tipo rock")
         assert p.artists_hint == ()
 
+    def test_artist_nao_vaza_para_positive(self):
+        """Regressão: `parse("tipo The HU")` devia ter positive=() e
+        artists_hint=('The HU',), não positive=('the',)."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo The HU")
+        assert "The HU" in p.artists_hint
+        assert p.positive == ()
+
+    def test_artist_e_genero_coexistem_na_mesma_clausula(self):
+        """Se o primeiro token é capitalizado (artist) o positive fica
+        vazio. Se artist vem depois, positive captura o primeiro token."""
+        from maestra_ai.core.context_parser import parse
+        # Primeiro token minúsculo → positive; artist detectado separadamente
+        p = parse("tipo metal Gojira")
+        assert "metal" in p.positive
+        assert "Gojira" in p.artists_hint
+
+
+class TestBpmRange:
+    def test_bpmrange_e_frozen(self):
+        from dataclasses import FrozenInstanceError
+        from maestra_ai.core.context_parser import BpmRange
+        b = BpmRange(min=100, max=120)
+        with pytest.raises(FrozenInstanceError):
+            b.min = 200  # type: ignore[misc]
+
+    def test_from_any_aceita_none(self):
+        from maestra_ai.core.context_parser import BpmRange
+        assert BpmRange.from_any(None) is None
+
+    def test_from_any_aceita_dict(self):
+        from maestra_ai.core.context_parser import BpmRange
+        b = BpmRange.from_any({"min": 100, "max": 120})
+        assert b == BpmRange(min=100, max=120)
+
+    def test_from_any_aceita_bpmrange_passa_direto(self):
+        from maestra_ai.core.context_parser import BpmRange
+        original = BpmRange(min=100, max=120)
+        assert BpmRange.from_any(original) is original
+
+    def test_from_any_rejeita_tipo_invalido(self):
+        from maestra_ai.core.context_parser import BpmRange
+        with pytest.raises(TypeError):
+            BpmRange.from_any("100-120")  # type: ignore[arg-type]
+
+
+class TestParsedContextHashable:
+    def test_hash_funciona_sem_bpm(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("foco")
+        hash(p)  # não deve explodir
+
+    def test_hash_funciona_com_bpm(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("foco", bpm={"min": 100, "max": 120})
+        hash(p)  # não deve explodir
+
+    def test_parse_com_dict_bpm_equivalente_a_parse_com_bpmrange(self):
+        from maestra_ai.core.context_parser import BpmRange, parse
+        p1 = parse("foco", bpm={"min": 100, "max": 120})
+        p2 = parse("foco", bpm=BpmRange(min=100, max=120))
+        assert p1 == p2
+        assert p1.bpm == BpmRange(min=100, max=120)
+
 
 class TestNormalizacao:
     def test_nao_e_nao_sao_equivalentes(self):

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -1,0 +1,24 @@
+"""Testes do parser de contexto (issue #8, v0.13)."""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+
+def test_parse_retorna_parsed_context_com_text_vazio_quando_input_vazio():
+    from maestra_ai.core.context_parser import ParsedContext, parse
+    p = parse("")
+    assert isinstance(p, ParsedContext)
+    assert p.text == ""
+    assert p.positive == ()
+    assert p.negative == ()
+    assert p.artists_hint == ()
+    assert p.bpm is None
+
+
+def test_parsed_context_e_frozen():
+    from maestra_ai.core.context_parser import ParsedContext
+    p = ParsedContext(text="x")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.text = "mudou"  # type: ignore[misc]

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -22,3 +22,31 @@ def test_parsed_context_e_frozen():
     p = ParsedContext(text="x")
     with pytest.raises(dataclasses.FrozenInstanceError):
         p.text = "mudou"  # type: ignore[misc]
+
+
+class TestNegativos:
+    def test_extrai_um_negativo_apos_evitar(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("metal evitar ambient")
+        assert "ambient" in p.negative
+
+    def test_extrai_um_negativo_apos_sem(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("rock sem ballads")
+        assert "ballads" in p.negative
+
+    def test_extrai_um_negativo_apos_nao(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("música não acústica")
+        assert "acústica" in p.negative
+
+    def test_extrai_multiplos_negativos_em_virgula(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("foco sem distração, evitar vocal")
+        assert "distração" in p.negative
+        assert "vocal" in p.negative
+
+    def test_nenhuma_negacao_retorna_tupla_vazia(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("metal tribal denso")
+        assert p.negative == ()

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -50,3 +50,43 @@ class TestNegativos:
         from maestra_ai.core.context_parser import parse
         p = parse("metal tribal denso")
         assert p.negative == ()
+
+
+class TestPositivos:
+    def test_extrai_termo_apos_tipo(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo lo-fi")
+        assert "lo-fi" in p.positive
+
+    def test_extrai_termo_apos_como(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("algo como jazz")
+        assert "jazz" in p.positive
+
+    def test_extrai_termo_apos_parecido_com(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("parecido com bossa")
+        assert "bossa" in p.positive
+
+    def test_positivo_e_negativo_coexistem(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo rock, sem ballads")
+        assert "rock" in p.positive
+        assert "ballads" in p.negative
+
+
+class TestArtistsHint:
+    def test_captura_nome_proprio_apos_marker_positivo(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo The HU")
+        assert "The HU" in p.artists_hint
+
+    def test_captura_multi_palavra_capitalizada(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("como Dance With The Dead")
+        assert "Dance With The Dead" in p.artists_hint
+
+    def test_palavra_minuscula_nao_vira_artist(self):
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo rock")
+        assert p.artists_hint == ()

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -397,3 +397,38 @@ class TestBuildInformedQuery:
         )
         q = curator._build_informed_query(self._ctx(negative=("ambient",)))
         assert q is None
+
+
+class TestCurateIntegracaoV013:
+    """Integração T11: curate() usa parsed + negative_filter + anti_tag_penalty."""
+
+    def test_curate_usa_parsed_context_quando_informado(self, curator, mock_controller, monkeypatch):
+        """curate() continua devolvendo tupla (tracks, queries, sources)."""
+        result = curator.curate("foco", count=3)
+        assert len(result) == 3  # (tracks, queries, sources)
+
+    def test_curate_aplica_negative_filter_e_reporta_queries(self, curator, mock_controller, monkeypatch):
+        """Com contexto 'rock evitar ambient', tracks retornadas não devem ter tag 'ambient'."""
+        from maestra_ai.core.external import cache as cache_mod
+        def fake_get(uri):
+            # URIs com "1" simulam tracks com tag ambient; outras ficam com rock
+            has_ambient = "1" in uri
+            return {"musicbrainz": {"tags": ["ambient"] if has_ambient else ["rock"]}}
+        monkeypatch.setattr(cache_mod, "get_track", fake_get)
+
+        tracks, _queries, _sources = curator.curate("rock evitar ambient", count=5)
+        for t in tracks:
+            cached = fake_get(t["uri"])
+            assert "ambient" not in (cached.get("musicbrainz") or {}).get("tags", [])
+
+    def test_curate_degraded_log_warning(self, curator, mock_controller, monkeypatch, caplog):
+        """Quando hard filter esvaziaria (todos candidatos têm tag negada), loga warning."""
+        import logging
+        from maestra_ai.core.external import cache as cache_mod
+        # Todos os candidatos passam a ter tag ambient → filtro esvazia → degrada
+        monkeypatch.setattr(cache_mod, "get_track",
+                            lambda uri: {"musicbrainz": {"tags": ["ambient"]}})
+
+        with caplog.at_level(logging.WARNING):
+            curator.curate("rock evitar ambient", count=3)
+        assert any("degrading to soft penalty" in r.message for r in caplog.records)

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -285,3 +285,53 @@ class TestTrackTags:
         from maestra_ai.core import curator as curator_mod
         monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: None)
         assert curator._track_tags({"artist": "A"}) == set()
+
+
+class TestApplyNegativeFilter:
+    def _ctx(self, neg):
+        from maestra_ai.core.context_parser import ParsedContext
+        return ParsedContext(text="dummy", negative=tuple(neg))
+
+    def test_sem_negacoes_no_op(self, curator):
+        candidates = [{"uri": f"spotify:track:{i}", "artist": "A"} for i in range(15)]
+        result, degraded = curator._apply_negative_filter(candidates, self._ctx([]))
+        assert result == candidates
+        assert degraded is False
+
+    def test_hard_filter_quando_acima_de_min_candidates(self, curator, monkeypatch):
+        from maestra_ai.core.external import cache as cache_mod
+        def fake_get(uri):
+            # URI "spotify:track:1" tem ambient; restantes têm rock.
+            # Usa comparação exata para evitar match em "spotify:track:11", etc.
+            return {"musicbrainz": {"tags": ["ambient"]}} if uri == "spotify:track:1" else {"musicbrainz": {"tags": ["rock"]}}
+        monkeypatch.setattr(cache_mod, "get_track", fake_get)
+
+        candidates = [{"uri": f"spotify:track:{i}", "artist": "A"} for i in range(20)]
+        # Apenas candidate ...1 tem ambient; outros têm rock. 1 remove → 19 sobram > 10
+        result, degraded = curator._apply_negative_filter(candidates, self._ctx(["ambient"]))
+        assert len(result) == 19
+        assert degraded is False
+
+    def test_degrada_quando_filtro_esvazia_abaixo_de_min(self, curator, monkeypatch):
+        from maestra_ai.core.external import cache as cache_mod
+        # Todos os candidatos têm "ambient"
+        monkeypatch.setattr(cache_mod, "get_track", lambda uri: {"musicbrainz": {"tags": ["ambient"]}})
+
+        candidates = [{"uri": f"spotify:track:{i}", "artist": "A"} for i in range(12)]
+        result, degraded = curator._apply_negative_filter(candidates, self._ctx(["ambient"]))
+        assert result == candidates  # originais preservados
+        assert degraded is True
+
+    def test_fronteira_exatamente_min_candidates_e_sucesso(self, curator, monkeypatch):
+        from maestra_ai.core.external import cache as cache_mod
+        def fake_get(uri):
+            # candidates 0..9 sem ambient; 10..14 com ambient
+            idx = int(uri.split(":")[-1])
+            return {"musicbrainz": {"tags": ["rock"] if idx < 10 else ["ambient"]}}
+        monkeypatch.setattr(cache_mod, "get_track", fake_get)
+
+        candidates = [{"uri": f"spotify:track:{i}", "artist": "A"} for i in range(15)]
+        # Após filter: 10 sobram (exatamente MIN_CANDIDATES=10)
+        result, degraded = curator._apply_negative_filter(candidates, self._ctx(["ambient"]))
+        assert len(result) == 10
+        assert degraded is False  # >= MIN_CANDIDATES aceita

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -408,18 +408,40 @@ class TestCurateIntegracaoV013:
         assert len(result) == 3  # (tracks, queries, sources)
 
     def test_curate_aplica_negative_filter_e_reporta_queries(self, curator, mock_controller, monkeypatch):
-        """Com contexto 'rock evitar ambient', tracks retornadas não devem ter tag 'ambient'."""
+        """Com contexto 'rock evitar ambient', tracks retornadas não devem ter tag 'ambient'.
+
+        Usa URIs distinguíveis (ambient_N vs rock_N) para garantir que o filtro
+        negativo seja realmente exercitado — e não passe de forma trivial.
+        """
         from maestra_ai.core.external import cache as cache_mod
+
+        # 3 candidatos ambient + 12 rock = 15 total; após filtro: 12 rock (>= MIN_CANDIDATES=10).
+        # Ambient URIs vêm PRIMEIRO na lista para garantir que, sem o filtro, eles
+        # apareceriam no top-5 retornado (teste falha com filtro quebrado).
+        ambient_uris = [f"spotify:track:ambient_{i}" for i in range(3)]
+        rock_uris = [f"spotify:track:rock_{i}" for i in range(12)]
+        all_uris = ambient_uris + rock_uris  # ambient primeiro → ranking favorece ambient sem filtro
+
+        mock_controller.search.return_value = [
+            {"uri": u, "track": "t", "artist": "A", "album": "Album"} for u in all_uris
+        ]
+
         def fake_get(uri):
-            # URIs com "1" simulam tracks com tag ambient; outras ficam com rock
-            has_ambient = "1" in uri
-            return {"musicbrainz": {"tags": ["ambient"] if has_ambient else ["rock"]}}
+            tags = ["ambient"] if "ambient" in uri else ["rock"]
+            return {"musicbrainz": {"tags": tags}}
+
         monkeypatch.setattr(cache_mod, "get_track", fake_get)
 
         tracks, _queries, _sources = curator.curate("rock evitar ambient", count=5)
-        for t in tracks:
-            cached = fake_get(t["uri"])
-            assert "ambient" not in (cached.get("musicbrainz") or {}).get("tags", [])
+
+        returned_uris = {t["uri"] for t in tracks}
+        # Nenhuma track com tag ambient deve ter passado pelo filtro
+        assert not any("ambient" in u for u in returned_uris), (
+            f"Negative filter deveria ter removido ambient tracks; retornou: {returned_uris}"
+        )
+        # Deve ter retornado ao menos uma track rock
+        assert len(tracks) > 0
+        assert all("rock" in u for u in returned_uris)
 
     def test_curate_degraded_log_warning(self, curator, mock_controller, monkeypatch, caplog):
         """Quando hard filter esvaziaria (todos candidatos têm tag negada), loga warning."""

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -234,3 +234,54 @@ class TestCuratorPrune:
         assert result["removed"] >= 1
         controller.playlist_remove.assert_called_once()
         assert result["snapshot_id"]  # id não-vazio
+
+
+class TestTrackTags:
+    """`_track_tags` consome cache external (MB canônico + LF filtrado)."""
+
+    def test_track_sem_entrada_no_cache_retorna_vazio(self, curator, monkeypatch):
+        # Sem entrada no cache → get_track retorna None → set() vazio.
+        from maestra_ai.core import curator as curator_mod
+        monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: None)
+        track = {"uri": "spotify:track:nao_cacheado", "artist": "X"}
+        assert curator._track_tags(track) == set()
+
+    def test_track_com_tags_mb_retorna_as_tags(self, curator, monkeypatch):
+        # MB traz tags canônicas; entram direto (lowercased).
+        from maestra_ai.core import curator as curator_mod
+        monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: {
+            "musicbrainz": {"tags": ["folk metal", "viking metal"]},
+        })
+        track = {"uri": "spotify:track:x", "artist": "A"}
+        tags = curator._track_tags(track)
+        assert "folk metal" in tags
+        assert "viking metal" in tags
+
+    def test_track_com_tags_lf_filtradas(self, curator, monkeypatch):
+        # Cache real: lastfm.top_tags é list[str]. Meta-tags (década) são descartadas.
+        from maestra_ai.core import curator as curator_mod
+        monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: {
+            "lastfm": {"top_tags": ["2010s", "shoegaze"]},
+        })
+        track = {"uri": "spotify:track:x", "artist": "A"}
+        tags = curator._track_tags(track)
+        assert "shoegaze" in tags
+        assert "2010s" not in tags
+
+    def test_merge_mb_e_lf(self, curator, monkeypatch):
+        # Merge MB (canônico) + LF (filtrado); duplicatas dedupadas pelo set.
+        from maestra_ai.core import curator as curator_mod
+        monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: {
+            "musicbrainz": {"tags": ["folk metal"]},
+            "lastfm": {"top_tags": ["viking"]},
+        })
+        track = {"uri": "spotify:track:x", "artist": "A"}
+        tags = curator._track_tags(track)
+        assert "folk metal" in tags
+        assert "viking" in tags
+
+    def test_uri_ausente_retorna_vazio(self, curator, monkeypatch):
+        # Track sem uri: evita passar string vazia adiante; retorna set() imediatamente.
+        from maestra_ai.core import curator as curator_mod
+        monkeypatch.setattr(curator_mod.cache_mod, "get_track", lambda uri: None)
+        assert curator._track_tags({"artist": "A"}) == set()

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -335,3 +335,65 @@ class TestApplyNegativeFilter:
         result, degraded = curator._apply_negative_filter(candidates, self._ctx(["ambient"]))
         assert len(result) == 10
         assert degraded is False  # >= MIN_CANDIDATES aceita
+
+
+class TestBuildInformedQuery:
+    def _ctx(self, **kwargs):
+        from maestra_ai.core.context_parser import ParsedContext
+        defaults = {"text": "", "positive": (), "negative": (), "artists_hint": (), "bpm": None}
+        defaults.update(kwargs)
+        return ParsedContext(**defaults)
+
+    def test_vazio_retorna_none(self, curator, monkeypatch):
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        assert curator._build_informed_query(self._ctx()) is None
+
+    def test_so_positivo_gera_query(self, curator, monkeypatch):
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(self._ctx(positive=("metal",)))
+        assert q is not None
+        assert "metal" in q
+
+    def test_positivo_e_artist_hint_combinam(self, curator, monkeypatch):
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(self._ctx(
+            positive=("metal",), artists_hint=("Gojira",)
+        ))
+        assert "Gojira" in q
+        assert "metal" in q
+
+    def test_bpm_adiciona_qualificador(self, curator, monkeypatch):
+        from maestra_ai.core.context_parser import BpmRange
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(self._ctx(
+            positive=("metal",), bpm=BpmRange(min=100, max=120)
+        ))
+        assert q is not None
+        assert "metal" in q
+        # Qualificador de bpm é adicionado — formato "110bpm" (média)
+        assert "110" in q or "bpm" in q.lower()
+
+    def test_so_taste_sem_positive_usa_top_artista(self, curator, monkeypatch):
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: ["Heilung"])
+        q = curator._build_informed_query(self._ctx())
+        assert q is not None
+        assert "Heilung" in q
+
+    def test_top_taste_negado_pula_pro_proximo(self, curator, monkeypatch):
+        monkeypatch.setattr(
+            curator.taste, "get_preferred_artists",
+            lambda: ["Ambient Band", "Heilung"]
+        )
+        q = curator._build_informed_query(self._ctx(negative=("ambient",)))
+        # "Ambient Band" tem "ambient" case-insensitive → pula
+        assert q is not None
+        assert "Heilung" in q
+        assert "Ambient" not in q
+
+    def test_todos_os_top_taste_negados_e_sem_positive_retorna_none(self, curator, monkeypatch):
+        monkeypatch.setattr(
+            curator.taste, "get_preferred_artists",
+            lambda: ["Ambient One", "Ambient Two", "Ambient Three"]
+        )
+        q = curator._build_informed_query(self._ctx(negative=("ambient",)))
+        assert q is None

--- a/packages/maestra-ai/tests/unit/test_scoring.py
+++ b/packages/maestra-ai/tests/unit/test_scoring.py
@@ -123,3 +123,32 @@ def test_compose_score_taste_negative_pulls_down():
     w = {"taste": 0.4, "tag": 0.3, "decade": 0.2, "bpm": 0.1}
     score = compose_score(weights=w, taste=-1.0, tag=0.0, decade=0.0, bpm=0.0)
     assert score == pytest.approx(-0.4)
+
+
+# ------- anti_tag_penalty -------
+
+class TestAntiTagPenalty:
+    def test_sem_overlap_retorna_zero(self):
+        from maestra_ai.core.scoring import anti_tag_penalty
+        assert anti_tag_penalty({"rock"}, {"ambient"}, degraded=True) == 0.0
+
+    def test_com_overlap_retorna_negativo(self):
+        from maestra_ai.core.scoring import anti_tag_penalty
+        p = anti_tag_penalty({"rock", "ambient"}, {"ambient"}, degraded=True)
+        assert p < 0
+
+    def test_degraded_false_sempre_zero(self):
+        from maestra_ai.core.scoring import anti_tag_penalty
+        assert anti_tag_penalty({"ambient"}, {"ambient"}, degraded=False) == 0.0
+
+    def test_multiplos_overlaps_penalizam_mais_ate_limite(self):
+        from maestra_ai.core.scoring import anti_tag_penalty
+        p1 = anti_tag_penalty({"a"}, {"a"}, degraded=True)
+        p2 = anti_tag_penalty({"a", "b"}, {"a", "b"}, degraded=True)
+        p5 = anti_tag_penalty({"a", "b", "c", "d", "e"}, {"a", "b", "c", "d", "e"}, degraded=True)
+        assert p2 < p1  # mais negativo
+        assert p5 <= p2  # não pior que 3 (limite em 3 pela spec)
+
+    def test_negative_tags_vazio_retorna_zero(self):
+        from maestra_ai.core.scoring import anti_tag_penalty
+        assert anti_tag_penalty({"rock"}, set(), degraded=True) == 0.0

--- a/packages/maestra-mcp/pyproject.toml
+++ b/packages/maestra-mcp/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Leonardo Menzani Silva" }
 ]
 dependencies = [
-    "maestra-ai>=0.12.0",
+    "maestra-ai>=0.13.0",
     "mcp>=1.0,<2.0",
     "jsonschema>=4.0,<5.0",
 ]

--- a/packages/maestra-mcp/src/maestra_mcp/instructions.py
+++ b/packages/maestra-mcp/src/maestra_mcp/instructions.py
@@ -86,11 +86,6 @@ DJ-explícito com filas curtas e intencionais.
   spawna `python -m maestra_ai.cli` que falha quando `__main__.py` está
   ausente no pacote. Prefira curadoria sob demanda via `play_context`
   até o fix chegar em produção.
-- **Curadoria automática não respeita negações no contexto** (issue #8,
-  v0.13): se o contexto ativo contém "evitar X" ou "sem Y", aplique
-  filtro manual após `play_context` — o scoring ainda não penaliza
-  tags negativas do cache external.
-
 Quando essas limitações forem resolvidas, os avisos correspondentes
 desta seção serão removidos.
 """

--- a/packages/maestra-mcp/tests/test_instructions.py
+++ b/packages/maestra-mcp/tests/test_instructions.py
@@ -50,16 +50,23 @@ def test_instructions_menciona_tools_criticas_por_nome():
         )
 
 
-def test_instructions_alerta_bugs_abertos():
-    """Enquanto #6 e #8 não forem fechadas, instructions devem alertar agentes.
-    Quando fecharem, remover os alertas e atualizar este teste."""
+def test_instructions_alerta_bug_6():
+    """Issue #6 ainda aberta — instructions devem alertar agentes sobre
+    director daemon. Quando fechar, remover o alerta e atualizar este teste."""
     from maestra_mcp.instructions import INSTRUCTIONS
-    # Referências a números de issue ou descrição dos bugs
     assert "#6" in INSTRUCTIONS or "director" in INSTRUCTIONS.lower(), (
         "alerta sobre issue #6 (director daemon) ausente"
     )
-    assert "#8" in INSTRUCTIONS or "negaç" in INSTRUCTIONS.lower() or "evitar" in INSTRUCTIONS.lower(), (
-        "alerta sobre issue #8 (negações no contexto) ausente"
+
+
+def test_instructions_nao_mais_alerta_sobre_8():
+    """Issue #8 foi resolvida em v0.13 — alerta deve ter sido removido."""
+    from maestra_mcp.instructions import INSTRUCTIONS
+    # Se este teste quebrar, algum refactor adicionou de volta o aviso
+    # equivocadamente — o fix já está em produção.
+    assert "#8" not in INSTRUCTIONS, (
+        "aviso sobre issue #8 voltou indevidamente — "
+        "a feature está implementada desde v0.13"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -491,7 +491,7 @@ wheels = [
 
 [[package]]
 name = "maestra-ai"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/maestra-ai" }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary

Implementa v0.13.0 do maestra-ai, resolvendo **issue #8**: curadoria respeita negações no contexto e usa tags reais do cache external no scoring composto. 17 commits TDD-drivem, 77 testes novos (suite 814 → 891), zero regressões.

### O que entra

- **Parser unificado** (`core/context_parser.py`, novo): `ParsedContext` frozen + `BpmRange` frozen + `parse()` com NFKC+casefold. Markers: `evitar/sem/não/nao` (negativos), `tipo/como/parecido com/mais` (positivos). Artistas capitalizados via regex ASCII.
- **`tag_filter.py`** (novo): `filter_lastfm_tags()` remove meta-tags (décadas, países, avaliativos), normaliza case, corta top_n.
- **`ContextState.parsed()`** memoizado por `(text, bpm)` com invalidação em `set()`/`clear()`/`clear_bpm()`.
- **`Curator._track_tags()`** real — consome cache external (MB canônico + LF filtrado). Encerra stub de v0.10.0-alpha.1.
- **`Curator._build_informed_query()`** real — deriva query de `ParsedContext × taste.get_preferred_artists()`, skip top taste que batem com `parsed.negative`. BPM vira qualificador.
- **`Curator._apply_negative_filter`** — hard filter adaptativo (< MIN_CANDIDATES → degraded=True + warning).
- **`scoring.anti_tag_penalty`** — ativa só quando degraded=True (W_ANTI_TAG=0.4 inicial).
- **`Curator.curate()`** — reescrito pra integrar tudo, aceita `str` ou `ParsedContext` (duck-typing).
- **MCP instructions**: aviso de #8 removido; teste convertido pra guarda de regressão.

### Divergências vs spec original (documentadas)

- **T4.5 inline fix** (commit `4676df6`): introduziu `BpmRange` frozen dataclass substituindo `dict` no campo `bpm` (ParsedContext era declarado hashable mas `dict` quebrava em runtime). Também fix de artist-leak: `parse("tipo The HU")` deixa de vazar `"the"` pra `positive`.
- **T7 descobriu**: shape real de `lastfm.top_tags` no cache é `list[str]`, não `list[dict]` como spec assumia. `_track_tags` usa wrap adapter como solução de curto prazo.

Spec MD e plan MD foram atualizados post-hoc (commit `9a8212e`) pra refletir a realidade do código.

## Tech debt pra issue #13 (já no CHANGELOG)

- `_extract_artists` regex só pega `[A-Z]` ASCII (miss em "José", "Ólafur")
- `_apply_negative_filter` só matcha tags, não nome de artista ("evitar Metallica" é no-op)
- Extração de negativo pega só primeiro token ("sem synth pesado" → drop "pesado")
- `lastfm.top_tags` shape unification (eliminar wrap adapter)
- Parser EN (avoid/without/no/like)
- Telemetria pra calibrar W_ANTI_TAG
- Hoist `_active_bpm_target()` fora do scoring loop

## Test Plan

- [x] Full suite verde via `uv run pytest -q` → **891 passed, 6 skipped**
- [x] TDD red-then-green verificado em cada task (commits individuais)
- [x] Fail-then-pass validado no teste de integração de negative filter (commit `b0a2c40`)
- [x] Final code review (Claude Opus) — "ready to merge with 1 asterisk" (asterisk resolvido em `b0a2c40`)
- [ ] Sanity check live: `maestra curate "rock evitar ambient"` retorna tracks sem tag ambient
- [ ] Sanity check live: `maestra curate "tipo The HU"` constrói query com artista, não com "the"

## Commits

```
6fbca0e feat(context_parser): scaffold ParsedContext + parse mínimo
08cba84 feat(context_parser): extrai negações após evitar/sem/não
2da8807 feat(context_parser): positivos + artists_hint
fea9b0a feat(context_parser): normalização NFKC + casefold no matching
4676df6 fix(context_parser): BpmRange hashable + artist não vaza para positive
f326358 feat(tag_filter): filtro de meta-tags Last.fm
5f28471 feat(context): ContextState.parsed() com memoização por text
3354969 feat(curator): _track_tags consome cache external (MB + LF)
44297ce feat(curator): _apply_negative_filter com fallback adaptativo
7112802 feat(scoring): anti_tag_penalty para modo degraded
84774d1 feat(curator): _build_informed_query real
5582838 feat(curator): integra parsed + negative_filter + anti_tag_penalty
c2e5dad chore: bump para v0.13.0 + CHANGELOG
0265af2 docs(mcp): remove aviso de #8 das instructions (fix em v0.13)
9a8212e docs(v0.13): spec + plan refletem T4.5 (BpmRange, artist leak, cache shape)
b0a2c40 test(curator): negative filter integration exercita tracks com tag real
6b977cf chore: update uv.lock para v0.13.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)