### PR TITLE
chore(lint): ruff --fix em arquivos do v0.13

### DIFF
--- a/docs/reviews/pending/v0.10-task3-followups.md
+++ b/docs/reviews/pending/v0.10-task3-followups.md
@@ -1,0 +1,35 @@
+# Task 3 (v0.10) — follow-ups de code quality
+
+Registrados durante subagent-driven execution; não bloqueiam progresso porque não são regressões funcionais.
+
+## [Important] `migrate_external_sources` muta in-place e retorna self
+
+- `config.py:55-67`
+- Contrato misto: assinatura `dict → dict` sugere new object, mas muta entrada.
+- Fix: docstring explicitando OU retornar `copy.deepcopy` antes de mutar.
+
+## [Important] `load_and_migrate` — detecção de mudança por key-set
+
+- `config.py:98-115`
+- `set(data.keys())` antes/depois não pega cfg com `external_sources` nested incompleto e sem flat key: arquivo em disco fica incompleto (runtime OK via `source_enabled` defensivo).
+- Fix: comparar dict profundo (`data != original`) ou sempre write-back após migração.
+
+## [Nit] Testes sem cobertura de `load_and_migrate` (I/O)
+
+- Adicionar 2 unit tests com mock de `storage.read_config/write_config`: (a) no write quando já migrado, (b) write-back quando houve mudança.
+
+## [Nit] Linhas >160 chars em `test_config_external_migration.py:44,57,60`
+
+- Extrair fixtures inline para variáveis locais.
+
+## [Nit] `test_any_source_enabled_helper` cobre 2 behaviors
+
+- Separar em `test_any_source_enabled_true_when_one_active` + `test_any_source_enabled_false_when_all_off`.
+
+## [Nit] Naming: `source_enabled` / `any_source_enabled`
+
+- Restante do codebase usa prefixo `is_`. Considerar padronização.
+
+---
+
+**Ação:** revisar em final code review antes da tag `v0.10.0`. Nenhum é blocking.

--- a/packages/maestra-ai/src/maestra_ai/core/context.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context.py
@@ -7,7 +7,8 @@ import json
 import os
 from datetime import datetime, timedelta
 
-from maestra_ai.core.context_parser import BpmRange, ParsedContext, parse as _parse_context
+from maestra_ai.core.context_parser import BpmRange, ParsedContext
+from maestra_ai.core.context_parser import parse as _parse_context
 from maestra_ai.core.storage import atomic_write_json
 
 _BPM_MIN = 30

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -11,7 +11,6 @@ import re
 import unicodedata
 from dataclasses import dataclass
 
-
 NEGATIVE_MARKERS: tuple[str, ...] = ("evitar ", "sem ", "não ", "nao ")
 
 # Ordenados do mais longo para o mais curto: "algo tipo " deve ser testado
@@ -33,7 +32,7 @@ class BpmRange:
     max: int | None = None
 
     @classmethod
-    def from_any(cls, value: "BpmRange | dict | None") -> "BpmRange | None":
+    def from_any(cls, value: BpmRange | dict | None) -> BpmRange | None:
         """Aceita BpmRange, dict com keys min/max, ou None. Normaliza para
         BpmRange. Usado por parse() e por ContextState.parsed() para ingress
         do formato {min, max} persistido em disco."""
@@ -100,7 +99,7 @@ def _extract_artists(original_clause: str) -> list[str]:
     return [m for m in matches if len(m) > 1]
 
 
-def parse(text: str, bpm: "BpmRange | dict | None" = None) -> ParsedContext:
+def parse(text: str, bpm: BpmRange | dict | None = None) -> ParsedContext:
     """Extrai intenção estruturada de texto livre.
 
     Puro, idempotente, determinístico. Nenhum I/O, nenhum logging.

--- a/packages/maestra-ai/src/maestra_ai/core/external/tag_filter.py
+++ b/packages/maestra-ai/src/maestra_ai/core/external/tag_filter.py
@@ -8,7 +8,6 @@ Issue #8, v0.13.
 """
 from __future__ import annotations
 
-
 META_TAGS: frozenset[str] = frozenset({
     # Décadas
     "1950s", "1960s", "1970s", "1980s", "1990s", "2000s", "2010s", "2020s",

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -112,6 +112,7 @@ class TestArtistsHint:
 class TestBpmRange:
     def test_bpmrange_e_frozen(self):
         from dataclasses import FrozenInstanceError
+
         from maestra_ai.core.context_parser import BpmRange
         b = BpmRange(min=100, max=120)
         with pytest.raises(FrozenInstanceError):

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -446,6 +446,7 @@ class TestCurateIntegracaoV013:
     def test_curate_degraded_log_warning(self, curator, mock_controller, monkeypatch, caplog):
         """Quando hard filter esvaziaria (todos candidatos têm tag negada), loga warning."""
         import logging
+
         from maestra_ai.core.external import cache as cache_mod
         # Todos os candidatos passam a ter tag ambient → filtro esvazia → degrada
         monkeypatch.setattr(cache_mod, "get_track",

--- a/packages/maestra-mcp/tests/test_instructions.py
+++ b/packages/maestra-mcp/tests/test_instructions.py
@@ -7,7 +7,6 @@ de memória estruturada.
 """
 from __future__ import annotations
 
-import pytest
 
 
 def test_instructions_module_exporta_constante():


### PR DESCRIPTION
## Summary

CI lint falhou após merge do #17 (v0.13). 6 violações detectadas pelo ruff:
- 5× `I001` (import block order)
- 1× `F401` (pytest import não usado)

Todas auto-fixáveis via `ruff --fix`. Ajustes adicionais de format aplicados pelo mesmo comando (9 fixes totais).

Não pegos pelos reviews 2-stage do #17 porque o spec e os implementers seguiam o estilo do próprio plano, que não era ruff-clean.

Também inclui: `docs/reviews/pending/v0.10-task3-followups.md` — arquivo de review pending pré-v0.13 que estava untracked desde antes da sessão; aproveitei pra commitá-lo.

## Test Plan

- [x] `uv run ruff check` → All checks passed!
- [x] `uv run pytest -q` → 891 passed, 6 skipped (sem regressões)
- [ ] CI verde após merge