### PR TITLE
fix(mcp): _curate desempacota 3 valores (v0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [maestra-mcp 0.9.1] — 2026-04-21
+
+### Corrigido
+- **MCP `curate` tool**: `_curate` desempacotava `curate()` em 2 valores
+  (`tracks, queries`), mas desde v0.12.0 (refactor #9) o `Curator.curate()`
+  retorna tupla de 3 (`tracks, queries_used, sources_used`). Cada invocação
+  via MCP explodia com `ValueError: too many values to unpack (expected 2)`.
+  Fix: desempacotar `tracks, queries, _sources`. Regressão latente por dois
+  releases — teste em `test_tools.py` mockava `return_value = ([], [])`, o
+  que reforçava o bug em vez de detectá-lo; teste agora usa tupla de 3.
+
 ## [0.13.0] — 2026-04-21
 
 ### Adicionado

--- a/packages/maestra-mcp/pyproject.toml
+++ b/packages/maestra-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestra-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "MCP stdio server for Maestra AI Spotify controller"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/maestra-mcp/src/maestra_mcp/tools.py
+++ b/packages/maestra-mcp/src/maestra_mcp/tools.py
@@ -206,7 +206,7 @@ def _curate(args):
     deps = build_deps()
     ctx = deps["context_state"].show()
     context_name = (ctx or {}).get("context", "default")
-    tracks, queries = deps["curator"].curate(
+    tracks, queries, _sources = deps["curator"].curate(
         context_name,
         count=args.get("max_tracks", 10),
         max_per_artist=args.get("max_per_artist", 1),

--- a/packages/maestra-mcp/tests/test_tools.py
+++ b/packages/maestra-mcp/tests/test_tools.py
@@ -45,7 +45,7 @@ async def test_set_context_chama_context_state_set():
 async def test_curate_passa_args_para_curator():
     from maestra_mcp.tools import call_tool
     mock_curator = MagicMock()
-    mock_curator.curate.return_value = ([], [])
+    mock_curator.curate.return_value = ([], [], [])
     mock_ctx = MagicMock()
     mock_ctx.show.return_value = {"context": "foco"}
     with patch("maestra_mcp.tools.build_deps",

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "maestra-mcp"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/maestra-mcp" }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

**Bug latente desde v0.12.0 do maestra-ai** (refactor #9) detectado agora ao testar o tool `mcp__maestra__curate` via MCP pela primeira vez após reinstalação da v0.13.0.

**Sintoma**: cada invocação via MCP explodia com `ValueError: too many values to unpack (expected 2)`.

**Causa**: `_curate` em `tools.py:209` fazia `tracks, queries = deps["curator"].curate(...)`, mas o refactor #9 no maestra-ai v0.12.0 mudou `Curator.curate()` pra retornar tupla de 3 (`tracks, queries_used, sources_used`). O MCP nunca foi atualizado.

**Por que o teste existente não pegou**: `test_curate_passa_args_para_curator` mockava `curate.return_value = ([], [])` — ou seja, o mock reforçava o bug (contrato mock ≠ contrato real). CLI paths (`cli/curate.py`, `cli/playlist.py`) funcionaram porque desempacotam a tupla de 3 corretamente desde o refactor.

## Fix (mínimo)

- `tools.py:209`: `tracks, queries = ...` → `tracks, queries, _sources = ...`
- `test_tools.py:48`: `return_value = ([], [])` → `([], [], [])` (agora reflete contrato real, serve como regressão)
- Bump `maestra-mcp` 0.9.0 → 0.9.1 (patch release, lint clean)

## Test Plan

- [x] `uv run ruff check packages/maestra-mcp` → All checks passed
- [x] `uv run pytest packages/maestra-mcp` → 58 passed
- [x] `uv run pytest -q` (full suite) → 891 passed, 6 skipped, zero regressões
- [ ] Após merge: reinstalar local via `uv tool install "maestra-mcp @ git+...@v0.9.1..."`, reiniciar MCP no Claude Code, retry `mcp__maestra__curate` → sucesso
- [ ] CI 3/3 verde no PR

## Lessons learned

Mocks de APIs internas devem espelhar o contrato real, não o comportamento observado — aqui, o mock tuple-de-2 cascateou um bug invisível por dois releases. Vale considerar fixture compartilhada `fake_curator` com `return_value` derivado do signature real do `Curator.curate()`, ou até um teste de contrato entre MCP tools e `maestra_ai.core`.