### PR TITLE
v0.14.0 — query builder fixes (closes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-04-21
+
+Release focada em aderência da curadoria ao contexto do usuário. Quatro bugs
+estruturais no pipeline de query-building foram catalogados empiricamente em
+três curadorias live (aderência 17–20%) e consolidados na issue #20:
+
+### Corrigido
+
+- **#20-2 (CRÍTICO) — `str(context_dict)` vazando como query ao Spotify.**
+  O MCP `_curate` passava o dict `ctx["context"]` (shape `{"text": ..., "bpm": ...}`)
+  ao `Curator.curate()`; em seguida `Curator._normalize_context` fazia
+  `str(context).strip()` sem checar tipo, gerando string literal de dict
+  (`"{'text': '...', 'bpm': none}"`). Essa string chegava ao fallback de
+  `_resolve_queries` e era enviada como `q=` ao Spotify, retornando `HTTP
+  400 Query exceeds maximum length of 250 characters`. Fix defense-in-depth
+  em duas camadas: `tools.py _curate` extrai `text` do dict antes de chamar
+  `curate()`; `Curator._normalize_context` também desempacota dict com campo
+  `text`. Fallback `"default"` redundante em `tools.py` removido — curator é
+  a única fonte de verdade para `DEFAULT_CONTEXT`.
+- **#20-3 — Parser extraía apenas 1 artist após marker `tipo`.**
+  `_split_clauses` fatia o texto por `,`, `.`, `;`. Entrada
+  `"tipo The HU, Wardruna, Nine Treasures"` virava 3 clauses; só a primeira
+  tinha marker, então `_extract_artists` só rodava nela. Os 5 artistas
+  subsequentes eram descartados silenciosamente. Fix em `context_parser.parse()`:
+  após detectar marker positivo, loop interno absorve clauses seguintes como
+  continuação da lista de artists, parando em (a) clause com marker próprio,
+  (b) clause não capitalizada, (c) clause sem artists extraíveis, (d) fim
+  do texto. Comportamento de negativos isolados preservado.
+- **#20-4 — Ausência de DSL Spotify `artist:"…"` causava prefix matching.**
+  `_build_informed_query` concatenava artist_hint como texto livre.
+  Query `"The HU"` retornava The Human League, The Hunter × 4, The Huntress,
+  The Hustle, The Hub, The Hum, The Hunger, e tracks do soundtrack de Hunger
+  Games. Fix: quando `parsed.artists_hint` (ou top taste filtrado por negative)
+  tem N > 0 artistas, montar query com `artist:"X" OR artist:"Y" OR ...`.
+  Positive e bpm seguem concatenados como texto livre. Aspas internas em nomes
+  de artista removidas antes do wrap. Helper `_fmt_artist_dsl` extraído e
+  reusado nos dois caminhos (artist_hint + fallback taste).
+- **#20-1 — Artist_hint sem validação causava polysemy lexical.**
+  `"Heilung"` (banda nórdica) colidia lexicalmente com tracks em alemão que
+  têm "Heilung" (cura) no título — Spotify retornava therapeutic music
+  alemã. Fix: camada de validação via MusicBrainz em `Curator._validate_artists_mb`,
+  chamada antes do `_fmt_artist_dsl`. Aceita artistas com score ≥ 85 no
+  `search_artists` da MB; rejeita o resto. Cache em memória por instância
+  evita lookups repetidos. Fallback gracioso: MB `None` (source não
+  configurada) → skip validação; exception → aceita (não penalizar por
+  instabilidade de rede). Wiring em `cli/__init__.py` e `mcp/deps.py` via
+  novo helper `build_musicbrainz_source_if_enabled()` em
+  `core/external/enhancer.py`.
+
+### Adicionado
+
+- `MusicBrainzSource.artist_exists(name) -> bool` — validação de existência
+  de artista com score-threshold parametrizado pela constante
+  `_MB_ARTIST_SCORE_THRESHOLD = 85`. Fallback gracioso em exception/timeout.
+- Parâmetro opcional `musicbrainz` em `Curator.__init__` (atributo
+  declarado, tipo `MusicBrainzSource | None`). Injetado automaticamente
+  pelos dois pontos de construção (CLI e MCP deps) quando
+  `external_sources.musicbrainz.enabled` for `True`.
+- `Curator._fmt_artist_dsl(names)` — formata lista de artists como DSL
+  Spotify (`artist:"X" OR artist:"Y"`), com remoção de aspas internas.
+- `Curator._validate_artists_mb(names)` — filtra lista via MB com cache
+  em memória por instância. Retorna lista intacta se MB não configurado.
+- `core/external/enhancer.build_musicbrainz_source_if_enabled()` — helper
+  que instancia `MusicBrainzSource` quando habilitado na config, senão
+  retorna `None`.
+
+### Diagnóstico empírico
+
+Três curadorias live em 2026-04-21 (contexto "metal tribal ritual com
+momentum operacional", referências The HU, Wardruna, Heilung) mostraram:
+
+| Curadoria | Query enviada | Aderência ao contexto |
+|---|---|---|
+| 15:58 | `"The HU Heilung"` | 1/6 = 17% |
+| 16:50 | `"The HU Heilung"` | 2/10 = 20% |
+| 17:20 | `"The HU"` (após reformulação) | 2/20 = 10% |
+
+A reformulação do contexto piorou o recall — evidência empírica de que a
+raiz era estrutural no pipeline, não no input. Validação pós-merge deve
+repetir o teste e verificar aderência > 70% (critério do spec).
+
+### Dependências
+
+- `musicbrainzngs` — agora também consumido em `artist_exists` via
+  `search_artists`. Rate limit de 1 req/s preservado pela config já
+  estabelecida em `MusicBrainzSource.__init__`.
+
+### Follow-ups conhecidos (issues abertas)
+
+- **#21** (`playlist TTL-aware`) — alinhar duração da playlist à janela do
+  TTL de contexto. Desbloqueado pela v0.14.0 (antes não fazia sentido com
+  curadoria a 10–20% de aderência).
+- Limitação pré-existente em `_extract_artists`: regex `[A-Z][A-Za-z]*` não
+  cobre diacríticos (Skáld trunca para `Sk`). Fora do escopo desta release.
+
 ## [maestra-mcp 0.9.1] — 2026-04-21
 
 ### Corrigido

--- a/docs/superpowers/specs/2026-04-21-v0140-query-builder-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-21-v0140-query-builder-fixes-design.md
@@ -1,0 +1,142 @@
+# v0.14.0 — Query builder fixes (curadoria aderente)
+
+**Data:** 2026-04-21
+**Issue principal:** [#20](https://github.com/mencoding/maestra-ai/issues/20) (4 bugs catalogados)
+**Issue dependente:** [#21](https://github.com/mencoding/maestra-ai/issues/21) — playlist TTL-aware (desbloqueia-se após v0.14)
+**Autor:** Léo + Claude (diagnóstico empírico live em 3 curadorias, 2026-04-21)
+**Status:** approved | **Branch:** `feat/issue-20-v0140-query-builder-fixes`
+
+---
+
+## Problema
+
+Três curadorias live hoje mostraram aderência inaceitável ao contexto "metal tribal ritual com momentum operacional":
+
+| Curadoria | Contexto | Query enviada ao Spotify | Aderência |
+|---|---|---|---|
+| 1ª (~15:58) | com `tipo The HU Heilung e Wardruna` | `"The HU Heilung"` | 1/6 = **17%** |
+| 2ª (~16:50) | idem | `"The HU Heilung"` | 2/10 = **20%** |
+| 3ª (~17:20) | reformulado com 6 artistas-guia | `"The HU"` | 2/20 = **10%** |
+
+Isso é evidência empírica de bugs estruturais no pipeline de query building. O bug #20 original (polysemy lexical do `Heilung` → cura alemã) expandiu para **4 bugs distintos** ao longo do diagnóstico.
+
+## Escopo
+
+Atacar os 4 bugs numa release única. Eles são inter-dependentes: resolver só um não melhora a aderência de forma útil.
+
+### Fora do escopo
+
+- Playlist TTL-aware (issue #21) — requer #20 resolvido como pré-condição
+- Parser bilíngue PT+EN (issue #13)
+- Refactor completo do `_resolve_queries` (múltiplas camadas: SEMANTIC_MAP, DESCRIPTOR_MAP, learned, DIRECT_PREFIXES, informed) — apenas o path informed é tocado
+- Rewrite do `_split_clauses` — correção cirúrgica, não refactor
+
+## Bugs catalogados
+
+### #20-1 — Polysemy lexical do artist_hint
+
+**Sintoma:** `Heilung` (banda nórdica) no contexto → query `"The HU Heilung"` → Spotify retorna tracks "Heilung der Seele", "Klänge der Heilung" (therapeutic music alemã, `Heilung` = cura).
+
+**Root cause:** `_extract_artists` em `context_parser.py:92` captura qualquer sequência capitalizada ASCII como artist_hint, sem validar que é uma banda real.
+
+**Correção:** validação via MusicBrainz (T4). Camada de defesa secundária — o fix primário é o T3 (DSL Spotify).
+
+### #20-2 — `str(context_dict)` vazando para query Spotify (CRÍTICO)
+
+**Sintoma:** Quando contexto não tem marker positivo (`tipo/como/parecido com/mais`), a API Spotify recebe:
+```
+q={'text': 'metal tribal ritual, momentum operacional...', 'bpm': none}
+```
+E retorna **HTTP 400 Bad Request** (`Query exceeds maximum length of 250 characters`).
+
+**Root cause (3 camadas):**
+
+1. **`tools.py:208`** (MCP):
+   ```python
+   context_name = (ctx or {}).get("context", "default")
+   ```
+   `ctx["context"]` é o dict `{"text": "...", "bpm": null}` — **não** a string de texto. A variável `context_name` recebe o dict, não um nome/texto.
+
+2. **`curator.py:414`** (`_normalize_context`):
+   ```python
+   context = str(context).strip()
+   ```
+   Converte o dict sem checar tipo. Resultado: string-repr-do-dict.
+
+3. **`curator.py:396`** (fallback em `_resolve_queries`):
+   ```python
+   return [context_lower]
+   ```
+   Nenhum match em SEMANTIC_MAP/DIRECT_PREFIXES/DESCRIPTOR_MAP (óbvio — a string-dict não casa com nada), então devolve a string-dict literal como query.
+
+**Correção:** defense in depth — fix nas 3 camadas (T1).
+
+### #20-3 — Parser extrai apenas 1 artist após marker
+
+**Sintoma:** Contexto `"tipo The HU, Wardruna, Nine Treasures, Tengger Cavalry, Eluveitie, Skáld"` → `queries_used = ["The HU"]`. Os outros 5 artistas são descartados silenciosamente.
+
+**Root cause:** `_split_clauses` em `context_parser.py:62` usa `re.split(r"[,.;]", text)`. A vírgula fatia a lista em múltiplas clauses — apenas a primeira (`"tipo The HU"`) tem marker `tipo`, então `_extract_after_marker_pair` só dispara lá.
+
+**Correção:** modificar `parse()` para, após detectar marker positivo numa clause, absorver clauses subsequentes como continuação até encontrar (a) clause com marker negativo, (b) clause sem letras capitalizadas iniciais (indicativo de trecho descritivo, não lista de artistas). Ver T2.
+
+### #20-4 — Ausência de DSL Spotify `artist:"…"` no query builder
+
+**Sintoma:** Query `"The HU"` (texto livre) faz o Spotify retornar tudo que começa com "The Hu": The Human League, The Hunter × 4, The Huntress, The Hustle, The Hub, The Hum, The Hunger, Hunger Games OST, etc.
+
+**Root cause:** `_build_informed_query` em `curator.py:56-89` concatena `artist_hint + positive + bpm` como texto livre. A API Spotify search com `q="The HU"` faz matching por prefixo lexical em título/artista/álbum, sem distinguir nome-próprio.
+
+**Correção:** quando `parsed.artists_hint` tem N > 0 itens, usar DSL: `artist:"X" OR artist:"Y" OR ...`. Escape de aspas internas. `positive` e `bpm` permanecem como texto livre concatenado (são descritores de gênero/ritmo). Ver T3.
+
+## Arquitetura
+
+### Unidades tocadas
+
+| Arquivo | Mudança |
+|---|---|
+| `packages/maestra-mcp/src/maestra_mcp/tools.py` | `_curate`: extrair `ctx["context"]["text"]` antes de passar para `curator.curate()` |
+| `packages/maestra-ai/src/maestra_ai/core/curator.py` | `_normalize_context`: aceitar ParsedContext/dict e extrair `.text`/`["text"]`; `_build_informed_query`: DSL Spotify quando há artists_hint; nova função de validação MB |
+| `packages/maestra-ai/src/maestra_ai/core/context_parser.py` | `parse()`: absorver clauses subsequentes como continuação de lista de artistas após marker positivo |
+| `packages/maestra-ai/tests/**` | testes novos cobrindo cada bug |
+
+### O que NÃO muda
+
+- Assinatura externa de `Curator.curate()` — continua `(tracks, queries, sources)`
+- Schema persistido `context.json` — intacto
+- Frozen dataclass `ParsedContext` + `BpmRange` — intactos
+- Comportamento do parser quando marker NÃO é encontrado — intacto (só extends após marker detectado)
+
+## Plano de tasks (TDD subagent-driven-dev)
+
+| # | Task | Escopo | Model |
+|---|---|---|---|
+| T1 | Bug #20-2 (crítico, 3 camadas) | tools.py, curator._normalize_context, testes | Sonnet |
+| T2 | Bug #20-3 (parser multi-artist) | context_parser.parse, testes | Sonnet |
+| T3 | Bug #20-4 (DSL Spotify) | curator._build_informed_query, testes | Sonnet |
+| T4 | Bug #20-1 (validação MB) | curator (novo helper), integração com external cache, testes | Sonnet |
+| T5 | Release v0.14.0 | CHANGELOG, bump, PR, merge, tag | Haiku |
+
+Ordem de execução: T1 → T2 → T3 → T4 → T5. Sequencial (branch única, evitar conflitos).
+
+## Critério de sucesso
+
+- Suite de testes verde (>=895 testes, +4 novos mínimo)
+- `ruff check` verde
+- Curadoria live pós-merge com mesmo contexto anterior deve produzir aderência > 70% (empírico — validar manual via MCP após release)
+- CHANGELOG.md registra os 4 fixes explicitamente
+- Tag v0.14.0 pushada, issue #20 fechada
+
+## Validação empírica pós-release
+
+Depois do merge + tag, rodar via MCP:
+
+```
+set_context(description="metal tribal, tipo The HU, Wardruna, Nine Treasures, evitar hip-hop, evitar ambient")
+curate(max_tracks=20, max_per_artist=2)
+```
+
+Verificar:
+- `queries_used` contém `artist:"The HU" OR artist:"Wardruna" OR artist:"Nine Treasures"`
+- Tracks retornados são majoritariamente dos artists pedidos (>=60%)
+- Nenhum "The Human League", "The Hustle", "Heilung der Seele" etc.
+
+Só aí a issue #21 (playlist TTL-aware) fica desbloqueada.

--- a/packages/maestra-ai/pyproject.toml
+++ b/packages/maestra-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestra-ai"
-version = "0.13.0"
+version = "0.14.0"
 description = "Spotify controller with context-aware curation for AI agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/maestra-ai/src/maestra_ai/cli/__init__.py
+++ b/packages/maestra-ai/src/maestra_ai/cli/__init__.py
@@ -189,7 +189,9 @@ def _build_deps(args: argparse.Namespace) -> dict:
     feedback_prompter = FeedbackPrompter(FEEDBACK_PROMPT_STATE_PATH)
     history_analyzer = HistoryAnalyzer(controller)
     flow_analyzer = FlowAnalyzer(taste)
-    curator = Curator(controller, taste)
+    from maestra_ai.core.external.enhancer import build_musicbrainz_source_if_enabled
+    mb_source = build_musicbrainz_source_if_enabled()
+    curator = Curator(controller, taste, musicbrainz=mb_source)
     # Subcomandos como auth, doctor, onboard podem rodar sem playlist_id.
     # Validação individual fica a cargo do caller que realmente precisa.
     try:

--- a/packages/maestra-ai/src/maestra_ai/core/context_parser.py
+++ b/packages/maestra-ai/src/maestra_ai/core/context_parser.py
@@ -119,7 +119,10 @@ def parse(text: str, bpm: BpmRange | dict | None = None) -> ParsedContext:
     positive: list[str] = []
     artists_hint: list[str] = []
 
-    for clause in _split_clauses(text):
+    clauses = _split_clauses(text)
+    i = 0
+    while i < len(clauses):
+        clause = clauses[i]
         clause_norm = _normalize_for_match(clause)
 
         neg = _extract_after_marker_pair(clause, clause_norm, neg_markers_norm)
@@ -128,6 +131,7 @@ def parse(text: str, bpm: BpmRange | dict | None = None) -> ParsedContext:
             parts = rest_orig.split()
             if parts:
                 negative.append(parts[0].casefold())
+            i += 1
             continue
 
         pos = _extract_after_marker_pair(clause, clause_norm, pos_markers_norm)
@@ -140,6 +144,29 @@ def parse(text: str, bpm: BpmRange | dict | None = None) -> ParsedContext:
             # texto original. Capitalizado = artist, tratado em _extract_artists.
             if parts and parts[0] and parts[0][0].islower():
                 positive.append(parts[0].casefold())
+            i += 1
+            # Absorver clauses seguintes como continuação da lista de artists
+            # até encontrar: (a) clause com marker próprio, (b) clause sem
+            # capitalização inicial (descritor, não nome-próprio), (c) clause
+            # sem artists extraíveis, ou (d) fim da lista.
+            while i < len(clauses):
+                next_clause = clauses[i].strip()
+                next_norm = _normalize_for_match(next_clause)
+                # Para se a próxima clause tem marker próprio (positivo ou negativo)
+                if any(m in next_norm for m in (neg_markers_norm + pos_markers_norm)):
+                    break
+                # Para se não começa com letra maiúscula (descritor, não artista)
+                if not next_clause or not next_clause[0].isupper():
+                    break
+                # Para se não extrai artistas reconhecíveis
+                more_artists = _extract_artists(next_clause)
+                if not more_artists:
+                    break
+                artists_hint.extend(more_artists)
+                i += 1
+            continue
+
+        i += 1
 
     return ParsedContext(
         text=text,

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -53,31 +53,36 @@ class Curator:
         self.controller = controller
         self.taste = taste
 
+    @staticmethod
+    def _fmt_artist_dsl(names: list[str]) -> str:
+        """Formata lista de artistas em DSL Spotify: artist:"X" OR artist:"Y".
+
+        Remove aspas internas do nome antes do wrap para garantir query válida.
+        """
+        clean = [a.replace('"', "") for a in names]
+        return " OR ".join(f'artist:"{a}"' for a in clean)
+
     def _build_informed_query(self, parsed) -> str | None:
         """Query informada a partir de ParsedContext + taste.
 
         Formato: "{dsl_artists} {positive} {bpm_qualifier}".
-        Artists são formatados com DSL Spotify: artist:"Nome" OR artist:"Outro".
-        Skip top taste que aparecem em negative. Retorna None se nenhum sinal.
+        Artists são formatados com DSL Spotify. Fallback em top taste pega
+        todos os candidatos não-negados (até 5). Retorna None se nenhum sinal.
         """
         negative = set(parsed.negative) if parsed.negative else set()
 
         # Parte 1: artistas com DSL Spotify (artist_hint tem prioridade sobre top taste)
         artist_part: str | None = None
         if parsed.artists_hint:
-            # Todos os artistas do hint, com aspas internas removidas para query válida
-            artists = [a.replace('"', "") for a in parsed.artists_hint]
-            artist_part = " OR ".join(f'artist:"{a}"' for a in artists)
+            artist_part = self._fmt_artist_dsl(list(parsed.artists_hint))
         else:
-            # Top preferred artists que não batam com negative — também usam DSL
             top = self.taste.get_preferred_artists() or []
             candidates = [
                 a for a in top[:5]
                 if not any(n in a.lower() for n in negative)
             ]
             if candidates:
-                artists = [a.replace('"', "") for a in candidates]
-                artist_part = " OR ".join(f'artist:"{a}"' for a in artists)
+                artist_part = self._fmt_artist_dsl(candidates)
 
         # Parte 2: positive (primeiro termo, se houver) — texto livre
         positive_part = parsed.positive[0] if parsed.positive else None

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -52,6 +52,10 @@ class Curator:
     def __init__(self, controller, taste):
         self.controller = controller
         self.taste = taste
+        # Cache em memória para evitar lookups repetidos ao MusicBrainz na mesma sessão.
+        # Chave: nome do artista (string original). Valor: bool (existe ou não).
+        # Invalidado apenas por reinício da instância — persistência fica como otimização futura.
+        self._mb_artist_cache: dict[str, bool] = {}
 
     @staticmethod
     def _fmt_artist_dsl(names: list[str]) -> str:
@@ -61,6 +65,26 @@ class Curator:
         """
         clean = [a.replace('"', "") for a in names]
         return " OR ".join(f'artist:"{a}"' for a in clean)
+
+    def _validate_artists_mb(self, names: list[str]) -> list[str]:
+        """Filtra lista de artistas mantendo apenas os reconhecidos pelo MusicBrainz.
+
+        Usa self.musicbrainz.artist_exists (score >= 85). Cache em memória evita
+        lookups repetidos para o mesmo nome dentro da mesma instância do Curator.
+
+        Se self.musicbrainz não estiver disponível, retorna a lista intacta
+        (não bloqueia quando a source não está configurada).
+        """
+        mb = getattr(self, "musicbrainz", None)
+        if mb is None:
+            return names
+        validated: list[str] = []
+        for name in names:
+            if name not in self._mb_artist_cache:
+                self._mb_artist_cache[name] = mb.artist_exists(name)
+            if self._mb_artist_cache[name]:
+                validated.append(name)
+        return validated
 
     def _build_informed_query(self, parsed) -> str | None:
         """Query informada a partir de ParsedContext + taste.
@@ -72,10 +96,15 @@ class Curator:
         negative = set(parsed.negative) if parsed.negative else set()
 
         # Parte 1: artistas com DSL Spotify (artist_hint tem prioridade sobre top taste)
+        # T4: valida artist_hint via MusicBrainz antes de usar (score >= 85).
+        # Se MB não configurado ou falhar, _validate_artists_mb retorna lista intacta.
         artist_part: str | None = None
         if parsed.artists_hint:
-            artist_part = self._fmt_artist_dsl(list(parsed.artists_hint))
-        else:
+            validated_hints = self._validate_artists_mb(list(parsed.artists_hint))
+            if validated_hints:
+                artist_part = self._fmt_artist_dsl(validated_hints)
+            # Se validated_hints vazio, cai no fallback de top taste (bloco else abaixo)
+        if not artist_part:
             top = self.taste.get_preferred_artists() or []
             candidates = [
                 a for a in top[:5]

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -49,9 +49,13 @@ MIN_CANDIDATES = 10
 class Curator:
     """Traduz contexto em queries de busca e retorna URIs filtradas."""
 
-    def __init__(self, controller, taste):
+    def __init__(self, controller, taste, *, musicbrainz=None):
         self.controller = controller
         self.taste = taste
+        # Source MusicBrainz opcional. Quando None, _validate_artists_mb vira no-op
+        # e artist_hint passa direto. Injetado pelos callers (cli, mcp/deps) quando
+        # ext_config["musicbrainz"]["enabled"] for True.
+        self.musicbrainz = musicbrainz
         # Cache em memória para evitar lookups repetidos ao MusicBrainz na mesma sessão.
         # Chave: nome do artista (string original). Valor: bool (existe ou não).
         # Invalidado apenas por reinício da instância — persistência fica como otimização futura.
@@ -69,19 +73,19 @@ class Curator:
     def _validate_artists_mb(self, names: list[str]) -> list[str]:
         """Filtra lista de artistas mantendo apenas os reconhecidos pelo MusicBrainz.
 
-        Usa self.musicbrainz.artist_exists (score >= 85). Cache em memória evita
-        lookups repetidos para o mesmo nome dentro da mesma instância do Curator.
+        Usa self.musicbrainz.artist_exists (score >= _MB_ARTIST_SCORE_THRESHOLD).
+        Cache em memória evita lookups repetidos para o mesmo nome dentro da
+        mesma instância do Curator.
 
-        Se self.musicbrainz não estiver disponível, retorna a lista intacta
-        (não bloqueia quando a source não está configurada).
+        Se self.musicbrainz for None, retorna a lista intacta (não bloqueia
+        quando a source não está configurada).
         """
-        mb = getattr(self, "musicbrainz", None)
-        if mb is None:
+        if self.musicbrainz is None:
             return names
         validated: list[str] = []
         for name in names:
             if name not in self._mb_artist_cache:
-                self._mb_artist_cache[name] = mb.artist_exists(name)
+                self._mb_artist_cache[name] = self.musicbrainz.artist_exists(name)
             if self._mb_artist_cache[name]:
                 validated.append(name)
         return validated

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -408,9 +408,16 @@ class Curator:
         return " ".join(descriptors)
 
     def _normalize_context(self, context):
-        """Retorna contexto utilizavel quando mood veio vazio."""
+        """Retorna contexto utilizavel quando mood veio vazio.
+
+        Aceita string, dict com campo 'text' (shape de ContextState.show()) ou None.
+        Evita vazar repr de dict como query literal ao Spotify (bug #20-2).
+        """
         if context is None:
             return DEFAULT_CONTEXT
+        # Desempacota dict {"text": "...", "bpm": ...} sem serializar com str()
+        if isinstance(context, dict):
+            context = context.get("text", "") or ""
         context = str(context).strip()
         return context or DEFAULT_CONTEXT
 

--- a/packages/maestra-ai/src/maestra_ai/core/curator.py
+++ b/packages/maestra-ai/src/maestra_ai/core/curator.py
@@ -56,24 +56,30 @@ class Curator:
     def _build_informed_query(self, parsed) -> str | None:
         """Query informada a partir de ParsedContext + taste.
 
-        Formato: "{artist_hint_ou_top_taste} {positive} {bpm_qualifier}".
+        Formato: "{dsl_artists} {positive} {bpm_qualifier}".
+        Artists são formatados com DSL Spotify: artist:"Nome" OR artist:"Outro".
         Skip top taste que aparecem em negative. Retorna None se nenhum sinal.
         """
         negative = set(parsed.negative) if parsed.negative else set()
 
-        # Parte 1: artista (artist_hint tem prioridade sobre top taste)
+        # Parte 1: artistas com DSL Spotify (artist_hint tem prioridade sobre top taste)
         artist_part: str | None = None
         if parsed.artists_hint:
-            artist_part = parsed.artists_hint[0]
+            # Todos os artistas do hint, com aspas internas removidas para query válida
+            artists = [a.replace('"', "") for a in parsed.artists_hint]
+            artist_part = " OR ".join(f'artist:"{a}"' for a in artists)
         else:
-            # Top preferred artist que não bata com negative
+            # Top preferred artists que não batam com negative — também usam DSL
             top = self.taste.get_preferred_artists() or []
-            for a in top[:5]:
-                if not any(n in a.lower() for n in negative):
-                    artist_part = a
-                    break
+            candidates = [
+                a for a in top[:5]
+                if not any(n in a.lower() for n in negative)
+            ]
+            if candidates:
+                artists = [a.replace('"', "") for a in candidates]
+                artist_part = " OR ".join(f'artist:"{a}"' for a in artists)
 
-        # Parte 2: positive (primeiro termo, se houver)
+        # Parte 2: positive (primeiro termo, se houver) — texto livre
         positive_part = parsed.positive[0] if parsed.positive else None
 
         # Parte 3: bpm qualifier — usa atributos do BpmRange (não dict)

--- a/packages/maestra-ai/src/maestra_ai/core/external/enhancer.py
+++ b/packages/maestra-ai/src/maestra_ai/core/external/enhancer.py
@@ -158,3 +158,19 @@ def default_enhancer() -> Enhancer:
         sources.append(ReccoBeatsSource())
 
     return Enhancer(sources=sources)
+
+
+def build_musicbrainz_source_if_enabled():
+    """Retorna MusicBrainzSource quando habilitado via config, senão None.
+
+    Usado por callers que querem injetar MB no Curator para validação de
+    artist_hint (v0.14.0 / #20-1), sem depender do Enhancer completo.
+    """
+    from maestra_ai import __version__
+    from maestra_ai.core.external.musicbrainz import MusicBrainzSource
+
+    cfg = _load_cfg()
+    ext = cfg.get("external_sources") or {}
+    if ext.get("musicbrainz", {}).get("enabled"):
+        return MusicBrainzSource(app_version=__version__)
+    return None

--- a/packages/maestra-ai/src/maestra_ai/core/external/musicbrainz.py
+++ b/packages/maestra-ai/src/maestra_ai/core/external/musicbrainz.py
@@ -91,6 +91,30 @@ class MusicBrainzSource:
             return self._lookup_by_name(name, artists[0])
         return None
 
+    def artist_exists(self, name: str) -> bool:
+        """Retorna True se houver match forte para o nome de artista no MusicBrainz.
+
+        Usa search_artists com score >= 85 como critério. Fallback gracioso
+        (retorna True) em caso de erro/timeout — evita penalizar usuário por
+        instabilidade da API externa.
+        """
+        if not name or not name.strip():
+            return False
+        try:
+            resp = musicbrainzngs.search_artists(artist=name, limit=1)
+        except Exception as e:
+            logger.debug("MB artist_exists falhou para %s: %s", name, e)
+            return True  # fallback gracioso: não rejeitar por falha de rede
+        artists = resp.get("artist-list") or []
+        if not artists:
+            return False
+        top = artists[0]
+        try:
+            score = int(top.get("ext:score", 0))
+        except (ValueError, TypeError):
+            score = 0
+        return score >= 85
+
     def _lookup_by_isrc(self, isrc: str) -> SourceResult | None:
         try:
             response = musicbrainzngs.get_recordings_by_isrc(isrc)

--- a/packages/maestra-ai/src/maestra_ai/core/external/musicbrainz.py
+++ b/packages/maestra-ai/src/maestra_ai/core/external/musicbrainz.py
@@ -62,6 +62,10 @@ _http_last_request_time: float = 0.0
 
 _MB_API_BASE = "https://musicbrainz.org/ws/2"
 
+# Score mínimo do search_artists para considerar artist real.
+# Valores abaixo indicam match fraco (nome parcial, aliás ambíguo).
+_MB_ARTIST_SCORE_THRESHOLD = 85
+
 
 class MusicBrainzSource:
     """Cliente `EnhancementSource` para MusicBrainz."""
@@ -94,9 +98,9 @@ class MusicBrainzSource:
     def artist_exists(self, name: str) -> bool:
         """Retorna True se houver match forte para o nome de artista no MusicBrainz.
 
-        Usa search_artists com score >= 85 como critério. Fallback gracioso
-        (retorna True) em caso de erro/timeout — evita penalizar usuário por
-        instabilidade da API externa.
+        Usa search_artists com score >= _MB_ARTIST_SCORE_THRESHOLD. Fallback
+        gracioso (retorna True) em caso de erro/timeout — evita penalizar
+        usuário por instabilidade da API externa.
         """
         if not name or not name.strip():
             return False
@@ -113,7 +117,7 @@ class MusicBrainzSource:
             score = int(top.get("ext:score", 0))
         except (ValueError, TypeError):
             score = 0
-        return score >= 85
+        return score >= _MB_ARTIST_SCORE_THRESHOLD
 
     def _lookup_by_isrc(self, isrc: str) -> SourceResult | None:
         try:

--- a/packages/maestra-ai/tests/unit/test_context_parser.py
+++ b/packages/maestra-ai/tests/unit/test_context_parser.py
@@ -157,6 +157,53 @@ class TestParsedContextHashable:
         assert p1.bpm == BpmRange(min=100, max=120)
 
 
+class TestMultiArtistAposMarker:
+    """Testes para o bug #20-3: parser absorve clauses subsequentes como
+    lista de artists após detectar marker positivo numa clause."""
+
+    def test_parse_captura_multiplos_artists_apos_tipo_com_virgulas(self):
+        """Input com lista de artistas separados por vírgula após 'tipo'
+        deve capturar todos os artistas, não apenas o primeiro."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo The HU, Wardruna, Nine Treasures")
+        assert p.artists_hint == ("The HU", "Wardruna", "Nine Treasures")
+
+    def test_parse_captura_multiplos_artists_com_negativo_depois(self):
+        """Lista de artistas deve ser interrompida ao encontrar clause
+        com marker negativo. Negativos posteriores devem ser capturados."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("metal ritual, tipo The HU, Wardruna, evitar hip-hop")
+        assert p.artists_hint == ("The HU", "Wardruna")
+        assert p.negative == ("hip-hop",)
+
+    def test_parse_para_lista_em_clause_minuscula(self):
+        """Clause que começa com letra minúscula não é artista — deve
+        interromper a absorção da lista."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo The HU, Wardruna, percussão densa")
+        assert p.artists_hint == ("The HU", "Wardruna")
+
+    def test_parse_regressao_artist_unico(self):
+        """Comportamento pré-fix deve ser preservado: um único artista
+        após marker continua funcionando."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo The HU")
+        assert p.artists_hint == ("The HU",)
+
+    def test_parse_regressao_negativos_isolados(self):
+        """Negativos isolados separados por vírgula não devem ser
+        afetados pela lógica de absorção de multi-artist."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("evitar hip-hop, evitar ambient")
+        assert p.negative == ("hip-hop", "ambient")
+
+    def test_parse_mantem_ordem_artists(self):
+        """Ordem de aparição dos artistas no texto deve ser preservada."""
+        from maestra_ai.core.context_parser import parse
+        p = parse("tipo Eluveitie, Wardruna, Nine Treasures")
+        assert p.artists_hint == ("Eluveitie", "Wardruna", "Nine Treasures")
+
+
 class TestNormalizacao:
     def test_nao_e_nao_sao_equivalentes(self):
         from maestra_ai.core.context_parser import parse

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -398,6 +398,74 @@ class TestBuildInformedQuery:
         q = curator._build_informed_query(self._ctx(negative=("ambient",)))
         assert q is None
 
+    # --- Testes T3: DSL Spotify artist:"..." (#20-4) ---
+
+    def test_build_informed_query_um_artist_hint_usa_dsl_spotify(self, curator, monkeypatch):
+        """N=1 artist_hint → query usa DSL artist:"Nome"."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(self._ctx(artists_hint=("The HU",)))
+        assert q is not None
+        assert 'artist:"The HU"' in q
+
+    def test_build_informed_query_multiplos_artists_concat_com_or(self, curator, monkeypatch):
+        """N=3 artists_hint → query usa DSL com OR entre todos."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(
+            self._ctx(artists_hint=("The HU", "Wardruna", "Heilung"))
+        )
+        assert q is not None
+        assert 'artist:"The HU"' in q
+        assert 'artist:"Wardruna"' in q
+        assert 'artist:"Heilung"' in q
+        assert " OR " in q
+
+    def test_build_informed_query_inclui_positive_livre(self, curator, monkeypatch):
+        """artist_hint + positive → DSL artist + texto livre para positive."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(
+            self._ctx(artists_hint=("The HU",), positive=("metal",))
+        )
+        assert q is not None
+        assert 'artist:"The HU"' in q
+        assert "metal" in q
+
+    def test_build_informed_query_inclui_bpm_livre(self, curator, monkeypatch):
+        """artist_hint + bpm → DSL artist + qualificador bpm como texto livre."""
+        from maestra_ai.core.context_parser import BpmRange
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(
+            self._ctx(artists_hint=("The HU",), bpm=BpmRange(min=100, max=140))
+        )
+        assert q is not None
+        assert 'artist:"The HU"' in q
+        # mid = (100+140)//2 = 120
+        assert "120bpm" in q
+
+    def test_build_informed_query_sem_artist_hint_usa_top_taste_com_dsl(self, curator, monkeypatch):
+        """Sem artists_hint, top taste também usa DSL artist:"..."."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: ["Heilung"])
+        q = curator._build_informed_query(self._ctx())
+        assert q is not None
+        assert 'artist:"Heilung"' in q
+
+    def test_build_informed_query_aspas_no_nome_artist(self, curator, monkeypatch):
+        """Aspas internas no nome do artista são removidas antes do wrap DSL."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(
+            self._ctx(artists_hint=('Foo "Bar" Baz',))
+        )
+        assert q is not None
+        # Aspas internas removidas → nome limpo entre as aspas externas da DSL
+        assert 'artist:"Foo Bar Baz"' in q
+        # Não deve ter aspas duplas dentro do valor da DSL
+        assert 'artist:"Foo "Bar" Baz"' not in q
+
+    def test_build_informed_query_sem_sinal_retorna_none(self, curator, monkeypatch):
+        """Regressão: sem artists_hint, sem taste e sem positive → None."""
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+        q = curator._build_informed_query(self._ctx())
+        assert q is None
+
 
 class TestCurateIntegracaoV013:
     """Integração T11: curate() usa parsed + negative_filter + anti_tag_penalty."""

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -588,10 +588,9 @@ class TestValidateArtistsMb:
     def test_build_informed_query_mb_ausente_mantem_artists(
         self, mock_controller, taste, monkeypatch
     ):
-        """Curator sem atributo musicbrainz → artists_hint passa direto sem validação."""
-        curator = Curator(mock_controller, taste)
-        # Garante que não há atributo musicbrainz (regressão: sem source)
-        assert not hasattr(curator, "musicbrainz")
+        """Curator com musicbrainz=None → artists_hint passa direto sem validação."""
+        curator = Curator(mock_controller, taste)  # default musicbrainz=None
+        assert curator.musicbrainz is None
         monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
 
         parsed = self._ctx(artists_hint=("FakeBand",))

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -448,6 +448,31 @@ class TestBuildInformedQuery:
         assert q is not None
         assert 'artist:"Heilung"' in q
 
+    def test_build_informed_query_top_taste_multiplos_candidatos_usa_or(self, curator, monkeypatch):
+        """Top taste com N>1 candidatos não-negados: todos entram na DSL via OR."""
+        monkeypatch.setattr(
+            curator.taste, "get_preferred_artists",
+            lambda: ["Heilung", "Wardruna", "The HU"],
+        )
+        q = curator._build_informed_query(self._ctx())
+        assert q is not None
+        assert 'artist:"Heilung"' in q
+        assert 'artist:"Wardruna"' in q
+        assert 'artist:"The HU"' in q
+        assert " OR " in q
+
+    def test_build_informed_query_top_taste_filtra_negados_e_mantem_resto(self, curator, monkeypatch):
+        """Top taste: artistas negados são filtrados; resto ainda entra via OR."""
+        monkeypatch.setattr(
+            curator.taste, "get_preferred_artists",
+            lambda: ["Heilung", "Wardruna", "The HU"],
+        )
+        q = curator._build_informed_query(self._ctx(negative=("heilung",)))
+        assert q is not None
+        assert 'artist:"Heilung"' not in q
+        assert 'artist:"Wardruna"' in q
+        assert 'artist:"The HU"' in q
+
     def test_build_informed_query_aspas_no_nome_artist(self, curator, monkeypatch):
         """Aspas internas no nome do artista são removidas antes do wrap DSL."""
         monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -550,6 +550,107 @@ class TestCurateIntegracaoV013:
         assert any("degrading to soft penalty" in r.message for r in caplog.records)
 
 
+class TestValidateArtistsMb:
+    """Testes para _validate_artists_mb e integração em _build_informed_query (T4)."""
+
+    def _ctx(self, **kwargs):
+        from maestra_ai.core.context_parser import ParsedContext
+        defaults = {"text": "", "positive": (), "negative": (), "artists_hint": (), "bpm": None}
+        defaults.update(kwargs)
+        return ParsedContext(**defaults)
+
+    def _make_curator_with_mb(self, mock_controller, taste, mb_mock):
+        """Cria Curator com atributo musicbrainz injetado (simulando source configurada)."""
+        c = Curator(mock_controller, taste)
+        c.musicbrainz = mb_mock
+        return c
+
+    def test_build_informed_query_valida_artists_via_mb(
+        self, mock_controller, taste, monkeypatch
+    ):
+        """MB valida 'The HU' (True) e rejeita 'FakeBand' (False).
+
+        Query resultante deve conter artist:"The HU" mas NÃO artist:"FakeBand".
+        """
+        mb_mock = MagicMock()
+        mb_mock.artist_exists.side_effect = lambda name: name == "The HU"
+
+        curator = self._make_curator_with_mb(mock_controller, taste, mb_mock)
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+
+        parsed = self._ctx(artists_hint=("The HU", "FakeBand"))
+        q = curator._build_informed_query(parsed)
+
+        assert q is not None
+        assert 'artist:"The HU"' in q
+        assert "FakeBand" not in q
+
+    def test_build_informed_query_mb_ausente_mantem_artists(
+        self, mock_controller, taste, monkeypatch
+    ):
+        """Curator sem atributo musicbrainz → artists_hint passa direto sem validação."""
+        curator = Curator(mock_controller, taste)
+        # Garante que não há atributo musicbrainz (regressão: sem source)
+        assert not hasattr(curator, "musicbrainz")
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: [])
+
+        parsed = self._ctx(artists_hint=("FakeBand",))
+        q = curator._build_informed_query(parsed)
+
+        assert q is not None
+        assert 'artist:"FakeBand"' in q
+
+    def test_build_informed_query_todos_invalidados_cai_no_top_taste(
+        self, mock_controller, taste, monkeypatch
+    ):
+        """MB rejeita todos os artists_hint → cai no fallback de top taste.
+
+        Top taste tem 'Heilung' → query deve usar Heilung via DSL.
+        """
+        mb_mock = MagicMock()
+        mb_mock.artist_exists.return_value = False  # rejeita tudo
+
+        curator = self._make_curator_with_mb(mock_controller, taste, mb_mock)
+        monkeypatch.setattr(curator.taste, "get_preferred_artists", lambda: ["Heilung"])
+
+        parsed = self._ctx(artists_hint=("FakeBand1", "FakeBand2"))
+        q = curator._build_informed_query(parsed)
+
+        assert q is not None
+        assert "Heilung" in q
+        assert "FakeBand" not in q
+
+    def test_validate_artists_mb_usa_cache_em_memoria(
+        self, mock_controller, taste, monkeypatch
+    ):
+        """Cache em memória: mesmo nome chamado 2x deve invocar MB apenas 1x."""
+        mb_mock = MagicMock()
+        mb_mock.artist_exists.return_value = True
+
+        curator = self._make_curator_with_mb(mock_controller, taste, mb_mock)
+
+        # Chama 2x com o mesmo nome
+        result1 = curator._validate_artists_mb(["The HU"])
+        result2 = curator._validate_artists_mb(["The HU"])
+
+        assert result1 == ["The HU"]
+        assert result2 == ["The HU"]
+        # MB deve ter sido consultado apenas 1x (cache evita segundo lookup)
+        assert mb_mock.artist_exists.call_count == 1
+
+    def test_validate_artists_mb_lista_vazia_retorna_vazia(
+        self, mock_controller, taste
+    ):
+        """Lista vazia de entrada → retorna lista vazia sem chamar MB."""
+        mb_mock = MagicMock()
+        curator = self._make_curator_with_mb(mock_controller, taste, mb_mock)
+
+        result = curator._validate_artists_mb([])
+
+        assert result == []
+        mb_mock.artist_exists.assert_not_called()
+
+
 class TestNormalizeContext:
     """Testes para _normalize_context — bug #20-2."""
 

--- a/packages/maestra-ai/tests/unit/test_curator.py
+++ b/packages/maestra-ai/tests/unit/test_curator.py
@@ -455,3 +455,36 @@ class TestCurateIntegracaoV013:
         with caplog.at_level(logging.WARNING):
             curator.curate("rock evitar ambient", count=3)
         assert any("degrading to soft penalty" in r.message for r in caplog.records)
+
+
+class TestNormalizeContext:
+    """Testes para _normalize_context — bug #20-2."""
+
+    def test_normalize_context_aceita_dict_com_text(self, curator):
+        """Dict com campo 'text' deve retornar apenas o valor texto."""
+        resultado = curator._normalize_context({"text": "metal ritual", "bpm": None})
+        assert resultado == "metal ritual"
+
+    def test_normalize_context_aceita_string(self, curator):
+        """String direta deve passar sem alteração (regressão)."""
+        resultado = curator._normalize_context("metal ritual")
+        assert resultado == "metal ritual"
+
+    def test_normalize_context_aceita_none(self, curator):
+        """None deve retornar DEFAULT_CONTEXT (regressão)."""
+        from maestra_ai.core.curator import DEFAULT_CONTEXT
+        resultado = curator._normalize_context(None)
+        assert resultado == DEFAULT_CONTEXT
+
+    def test_normalize_context_dict_sem_text(self, curator):
+        """Dict sem campo 'text' deve retornar DEFAULT_CONTEXT."""
+        from maestra_ai.core.curator import DEFAULT_CONTEXT
+        resultado = curator._normalize_context({"bpm": None})
+        assert resultado == DEFAULT_CONTEXT
+
+    def test_normalize_context_nao_serializa_dict_como_query(self, curator):
+        """Garantir que dict com bpm nunca vira repr literal na query."""
+        resultado = curator._normalize_context({"text": "foo", "bpm": None})
+        assert "{" not in resultado
+        assert "'bpm'" not in resultado
+        assert "none" not in resultado.lower()

--- a/packages/maestra-ai/tests/unit/test_musicbrainz.py
+++ b/packages/maestra-ai/tests/unit/test_musicbrainz.py
@@ -1,0 +1,76 @@
+"""Testes unitários para MusicBrainzSource — foco em artist_exists (T4)."""
+from unittest.mock import patch
+
+import pytest
+
+from maestra_ai.core.external.musicbrainz import MusicBrainzSource
+
+
+@pytest.fixture
+def mb():
+    """MusicBrainzSource com versão fake (evita chamadas reais ao set_useragent)."""
+    with patch("musicbrainzngs.set_useragent"), patch("musicbrainzngs.set_rate_limit"):
+        return MusicBrainzSource(app_version="0.0.0-test")
+
+
+class TestArtistExists:
+    """Testes para MusicBrainzSource.artist_exists."""
+
+    def test_artist_exists_retorna_true_com_score_alto(self, mb):
+        """Mock search_artists com score 95 → deve retornar True."""
+        resp = {"artist-list": [{"ext:score": "95", "id": "abc", "name": "The HU"}]}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("The HU") is True
+
+    def test_artist_exists_retorna_false_score_baixo(self, mb):
+        """Mock search_artists com score 40 → deve retornar False (abaixo de 85)."""
+        resp = {"artist-list": [{"ext:score": "40", "id": "xyz", "name": "FakeBand"}]}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("FakeBand") is False
+
+    def test_artist_exists_retorna_false_lista_vazia(self, mb):
+        """Mock search_artists retornando lista vazia → deve retornar False."""
+        resp = {"artist-list": []}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("BandaInexistente") is False
+
+    def test_artist_exists_fallback_true_em_exception(self, mb):
+        """MB lança exceção → fallback gracioso deve retornar True (não penalizar)."""
+        with patch("musicbrainzngs.search_artists", side_effect=Exception("timeout")):
+            assert mb.artist_exists("QualquerBanda") is True
+
+    def test_artist_exists_false_para_string_vazia(self, mb):
+        """String vazia → deve retornar False sem chamar a API."""
+        with patch("musicbrainzngs.search_artists") as mock_search:
+            assert mb.artist_exists("") is False
+            mock_search.assert_not_called()
+
+    def test_artist_exists_false_para_string_apenas_espacos(self, mb):
+        """String de só espaços → deve retornar False sem chamar a API."""
+        with patch("musicbrainzngs.search_artists") as mock_search:
+            assert mb.artist_exists("   ") is False
+            mock_search.assert_not_called()
+
+    def test_artist_exists_score_exatamente_85_retorna_true(self, mb):
+        """Score exatamente no limiar (85) → deve retornar True (>= 85)."""
+        resp = {"artist-list": [{"ext:score": "85", "id": "lim", "name": "Limiar"}]}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("Limiar") is True
+
+    def test_artist_exists_score_84_retorna_false(self, mb):
+        """Score 84 (abaixo do limiar) → deve retornar False."""
+        resp = {"artist-list": [{"ext:score": "84", "id": "sub", "name": "SubLimiar"}]}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("SubLimiar") is False
+
+    def test_artist_exists_score_invalido_retorna_false(self, mb):
+        """Score não-numérico → int() falha → score=0 → False."""
+        resp = {"artist-list": [{"ext:score": "n/a", "id": "inv", "name": "ScoreInvalido"}]}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("ScoreInvalido") is False
+
+    def test_artist_exists_sem_artist_list_retorna_false(self, mb):
+        """Resposta sem chave 'artist-list' → deve retornar False."""
+        resp = {}
+        with patch("musicbrainzngs.search_artists", return_value=resp):
+            assert mb.artist_exists("Fantasma") is False

--- a/packages/maestra-mcp/src/maestra_mcp/deps.py
+++ b/packages/maestra-mcp/src/maestra_mcp/deps.py
@@ -60,7 +60,9 @@ def _build_and_cache() -> dict:
     controller = SpotifyController()
     history_analyzer = HistoryAnalyzer(controller)
     flow_analyzer = FlowAnalyzer(taste)
-    curator = Curator(controller, taste)
+    from maestra_ai.core.external.enhancer import build_musicbrainz_source_if_enabled
+    mb_source = build_musicbrainz_source_if_enabled()
+    curator = Curator(controller, taste, musicbrainz=mb_source)
     playback_observer = PlaybackObserver(
         str(base / "playback_state.json"),
         str(base / "playback_events.jsonl"),

--- a/packages/maestra-mcp/src/maestra_mcp/tools.py
+++ b/packages/maestra-mcp/src/maestra_mcp/tools.py
@@ -205,21 +205,20 @@ def _clear_context(args):
 def _curate(args):
     deps = build_deps()
     ctx = deps["context_state"].show()
-    raw_context = (ctx or {}).get("context", "default")
+    raw_context = (ctx or {}).get("context")
     # Desempacota dict {"text": "...", "bpm": ...} antes de passar ao curator.
-    # ctx["context"] é o objeto completo retornado por ContextState.show(),
-    # não uma string — sem este fix o dict vaza como repr literal (bug #20-2).
-    if isinstance(raw_context, dict):
-        context_name = raw_context.get("text") or "default"
-    else:
-        context_name = raw_context or "default"
+    # Fallback para contexto vazio/None fica sob responsabilidade do curator
+    # (DEFAULT_CONTEXT = "foco"), evitando duplicação de source-of-truth.
+    context_text = (
+        raw_context.get("text") if isinstance(raw_context, dict) else raw_context
+    )
     tracks, queries, _sources = deps["curator"].curate(
-        context_name,
+        context_text,
         count=args.get("max_tracks", 10),
         max_per_artist=args.get("max_per_artist", 1),
     )
     return {
-        "context": context_name,
+        "context": context_text or "",
         "tracks": tracks,
         "queries_used": queries,
     }

--- a/packages/maestra-mcp/src/maestra_mcp/tools.py
+++ b/packages/maestra-mcp/src/maestra_mcp/tools.py
@@ -205,7 +205,14 @@ def _clear_context(args):
 def _curate(args):
     deps = build_deps()
     ctx = deps["context_state"].show()
-    context_name = (ctx or {}).get("context", "default")
+    raw_context = (ctx or {}).get("context", "default")
+    # Desempacota dict {"text": "...", "bpm": ...} antes de passar ao curator.
+    # ctx["context"] é o objeto completo retornado por ContextState.show(),
+    # não uma string — sem este fix o dict vaza como repr literal (bug #20-2).
+    if isinstance(raw_context, dict):
+        context_name = raw_context.get("text") or "default"
+    else:
+        context_name = raw_context or "default"
     tracks, queries, _sources = deps["curator"].curate(
         context_name,
         count=args.get("max_tracks", 10),

--- a/packages/maestra-mcp/tests/test_tools.py
+++ b/packages/maestra-mcp/tests/test_tools.py
@@ -57,6 +57,30 @@ async def test_curate_passa_args_para_curator():
 
 
 @pytest.mark.asyncio
+async def test_curate_desempacota_context_text_do_dict():
+    """Bug #20-2: _curate deve extrair text do dict context antes de chamar curator."""
+    from maestra_mcp.tools import call_tool
+    mock_curator = MagicMock()
+    mock_curator.curate.return_value = ([], [], [])
+    mock_ctx = MagicMock()
+    # Simula exatamente o shape retornado por context_state.show() em produção
+    mock_ctx.show.return_value = {
+        "context": {"text": "metal tribal ritual", "bpm": None},
+        "set_at": "2026-04-21T17:00:00",
+        "ttl_minutes": 120,
+    }
+    with patch("maestra_mcp.tools.build_deps",
+               return_value={"curator": mock_curator, "context_state": mock_ctx}):
+        await call_tool("curate", {"max_tracks": 5})
+    assert mock_curator.curate.called
+    # O primeiro argumento posicional deve ser a string extraída, não o dict
+    primeiro_arg = mock_curator.curate.call_args.args[0]
+    assert primeiro_arg == "metal tribal ritual", (
+        f"Esperado 'metal tribal ritual', recebido: {primeiro_arg!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_maestra_error_vira_error_dict():
     from maestra_mcp.tools import call_tool
     from maestra_ai.core.errors import AuthError


### PR DESCRIPTION
## Summary

Release v0.14.0 corrige 4 bugs estruturais no pipeline de query-building, diagnosticados empiricamente em curadorias live hoje (2026-04-21). Aderência ao contexto do usuário subia de 10-20% (prefix matching destrutivo, polysemy lexical, `str(dict)` vazando como query) para comportamento esperado via DSL Spotify + parser multi-artist + validação MusicBrainz.

Closes #20 (cobrindo os 4 bugs #20-1, #20-2, #20-3, #20-4 catalogados no comment trail da issue).

## Bugs corrigidos

- **#20-2 (crítico)** — `str(context_dict)` vazando para Spotify search como query literal (HTTP 400). Fix nas 2 camadas de entrada (`tools.py _curate` + `curator._normalize_context`).
- **#20-3** — parser extraía apenas 1 artist após marker `tipo`, descartando lista com vírgulas. Loop interno em `context_parser.parse()` absorve clauses seguintes como continuação.
- **#20-4** — query builder concatenava artist_hint como texto livre, causando prefix matching destrutivo (`"The HU"` → The Human League, The Hunter × 4, etc.). Agora usa DSL Spotify `artist:"X" OR artist:"Y"`.
- **#20-1** — artist_hint sem validação causava polysemy lexical (`Heilung` → banda nórdica ou "cura" em alemão). Nova camada de validação via `MusicBrainzSource.artist_exists` com score >= 85. Fallback gracioso se MB offline/não configurado.

## Mudanças estruturais

- `MusicBrainzSource.artist_exists(name) -> bool` + constante `_MB_ARTIST_SCORE_THRESHOLD = 85`
- `Curator.__init__` aceita `musicbrainz` opcional, atributo declarado e tipado
- `Curator._fmt_artist_dsl` + `Curator._validate_artists_mb` helpers novos
- `build_musicbrainz_source_if_enabled()` em `core/external/enhancer.py` — wiring automático via config
- `cli/__init__.py` e `mcp/deps.py` injetam MB source quando `external_sources.musicbrainz.enabled`

## Suite

- **927 passed, 6 skipped** (baseline 891 → +36 testes novos nos 4 bugs)
- **Ruff**: All checks passed
- 8 commits (4 fixes principais + 3 follow-ups de code review + 1 release bump)

## Spec

Detalhes completos em `docs/superpowers/specs/2026-04-21-v0140-query-builder-fixes-design.md`.

## Validação pós-merge (manual)

Repetir curadoria com mesmo contexto anterior via MCP:
```
set_context(description="metal tribal ritual, tipo The HU, Wardruna, Nine Treasures, evitar hip-hop, evitar ambient")
curate(max_tracks=20, max_per_artist=2)
```
Esperado: `queries_used` contém `artist:"The HU" OR artist:"Wardruna" OR artist:"Nine Treasures"`; aderência > 70%; nenhum The Human League / Heilung alemão.

## Follow-ups (não-bloqueantes)

- **#21** (playlist TTL-aware) desbloqueado pela v0.14.0
- Regex ASCII em `_extract_artists` não cobre diacríticos (Skáld → `Sk`) — abrir issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)